### PR TITLE
Make Scouts always available

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -101,7 +101,6 @@
 		"cost": 25,		
 		"upgradesTo": "Gunman",
 		"hurryCostModifier": 20,
-		"obsoleteTech": "Rifling",
 		"uniques": ["Low Tech",
 			"[-50]% Strength <vs cities>"],
 		"promotions": ["Reconnaissance I","Skirmish"],


### PR DESCRIPTION
It's bad that Scout become obsolete. It's always actual - for garrison city as police, explore map doesn't need serious weapon, defend workers and upgrading to Gunman or Rifleman if weapon available with very nice traits. https://github.com/SpacedOutChicken/DeCiv-Redux/issues/19