### PR TITLE
Make government buildings only avaliable in capital

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -25,7 +25,8 @@
 			"Can only be built [in capital]",
 			"Gain a free [Deep Larder] [in this city]"
 		],
-		"quote": "An armed society is a polite society."
+		"quote": "An armed society is a polite society.",
+		"civilopediaText": [{ "text": "An armed society is a polite society."}]
 	},
 	{
 		"name": "Ark One",
@@ -43,7 +44,8 @@
 			"Can only be built [in capital]",
 			"Gain a free [Food Store] [in this city]"
 		],
-		"quote": "While your deposit clears, you may want to read through this guide for potential residents. The Ark One shelter comprises a unique set of secure luxury accomodation based within a former military facility. In addition to their private living space, residents will have access to a complete set of facilities including two restaurants, a cinema, a bowling alley, and a fitness area with gym, spa, sauna and pool. The Ark One shelter is protected by a world-class professional security company, and is hardened to resist a nuclear strike and any armed attack."
+		"quote": "While your deposit clears, you may want to read through this guide for potential residents. The Ark One shelter comprises a unique set of secure luxury accomodation based within a former military facility. In addition to their private living space, residents will have access to a complete set of facilities including two restaurants, a cinema, a bowling alley, and a fitness area with gym, spa, sauna and pool. The Ark One shelter is protected by a world-class professional security company, and is hardened to resist a nuclear strike and any armed attack.",
+		"civilopediaText": [{ "text": "While your deposit clears, you may want to read through this guide for potential residents. The Ark One shelter comprises a unique set of secure luxury accomodation based within a former military facility. In addition to their private living space, residents will have access to a complete set of facilities including two restaurants, a cinema, a bowling alley, and a fitness area with gym, spa, sauna and pool. The Ark One shelter is protected by a world-class professional security company, and is hardened to resist a nuclear strike and any armed attack."}]
 	},
 	{
 		"name": "Atlas Refuge",
@@ -59,7 +61,8 @@
 			"Can only be built [in capital]",
 			"Gain a free [Food Store] [in this city]"
 		],
-		"quote": "At the Refuge, I am creating more than a town, more even than a polity; it is a new world, where individuals will be free to act without the burden of taxation or the specter of injustice. Here, I have created a truly voluntary society, where the citizens associate in rational self interest; from love, not from fear of punishment. I have sent you this invitation because you have greatness within you; think of all you have achieved in your life, and how much more you could do, if you were not held back. Choose something different. Choose Atlas."
+		"quote": "At the Refuge, I am creating more than a town, more even than a polity; it is a new world, where individuals will be free to act without the burden of taxation or the specter of injustice. Here, I have created a truly voluntary society, where the citizens associate in rational self interest; from love, not from fear of punishment. I have sent you this invitation because you have greatness within you; think of all you have achieved in your life, and how much more you could do, if you were not held back. Choose something different. Choose Atlas.",
+		"civilopediaText": [{ "text": "At the Refuge, I am creating more than a town, more even than a polity; it is a new world, where individuals will be free to act without the burden of taxation or the specter of injustice. Here, I have created a truly voluntary society, where the citizens associate in rational self interest; from love, not from fear of punishment. I have sent you this invitation because you have greatness within you; think of all you have achieved in your life, and how much more you could do, if you were not held back. Choose something different. Choose Atlas."}]
 	},
 	{
 		"name": "Eagle Rock Complex",
@@ -78,7 +81,8 @@
 			"Can only be built [in capital]",
 			"Gain a free [Food Store] [in this city]"
 		],
-		"quote": "We are here to protect the people, and we will do it here. Here we make our stand against anarchy and tyranny. Here, we will once again establish freedom and order. This is the oath we have taken, and we will keep that oath."
+		"quote": "We are here to protect the people, and we will do it here. Here we make our stand against anarchy and tyranny. Here, we will once again establish freedom and order. This is the oath we have taken, and we will keep that oath.",
+		"civilopediaText": [{ "text": "We are here to protect the people, and we will do it here. Here we make our stand against anarchy and tyranny. Here, we will once again establish freedom and order. This is the oath we have taken, and we will keep that oath."}]
 	},
 	{
 		"name": "Forum",
@@ -91,7 +95,8 @@
 			"Free [Swordsman] appears",
 			"Can only be built [in capital]"
 		],
-		"quote": "Whatsoever any man either doth or saith, thou must be good; not for any man's sake, but for thine own nature's sake; as if either gold, or the emerald, or purple, should ever be saying to themselves, Whatsoever any man either doth or saith, I must still be an emerald, and I must keep my colour."
+		"quote": "Whatsoever any man either doth or saith, thou must be good; not for any man's sake, but for thine own nature's sake; as if either gold, or the emerald, or purple, should ever be saying to themselves, Whatsoever any man either doth or saith, I must still be an emerald, and I must keep my colour.",
+		"civilopediaText": [{ "text": "Whatsoever any man either doth or saith, thou must be good; not for any man's sake, but for thine own nature's sake; as if either gold, or the emerald, or purple, should ever be saying to themselves, Whatsoever any man either doth or saith, I must still be an emerald, and I must keep my colour."}]
 	},
 	{
 		"name": "Temple",
@@ -107,7 +112,8 @@
 			"Can only be built [in capital]",
 			"Gain a free [Fuel Depot] [in this city]"
 		],
-		"quote": "Be thy hands, anointed, with holy oil.\nBe thy breast, anointed, with holy oil.\nBe thy head, anointed, with holy oil.\nAs kings, priests, and prophets were anointed.\nAnd as Solomon was anointed king by Zadok the priest and Nathan the prophet, so be you anointed."
+		"quote": "Be thy hands, anointed, with holy oil.\nBe thy breast, anointed, with holy oil.\nBe thy head, anointed, with holy oil.\nAs kings, priests, and prophets were anointed.\nAnd as Solomon was anointed king by Zadok the priest and Nathan the prophet, so be you anointed.",
+		"civilopediaText": [{ "text": "Be thy hands, anointed, with holy oil.\nBe thy breast, anointed, with holy oil.\nBe thy head, anointed, with holy oil.\nAs kings, priests, and prophets were anointed.\nAnd as Solomon was anointed king by Zadok the priest and Nathan the prophet, so be you anointed."}]
 	},
 	{
 		"name": "Peace Memorial",
@@ -121,7 +127,8 @@
 			"Can only be built [in capital]",
 			"Gain a free [Monument] [in this city]"
 		],
-		"quote": "Lasting peace is sought, it is essential to adopt international measures to improve the lot of the masses. The welfare of the entire human race must replace hunger and oppression. People of the world must be taught to give up envy, avarice and rancour."
+		"quote": "Lasting peace is sought, it is essential to adopt international measures to improve the lot of the masses. The welfare of the entire human race must replace hunger and oppression. People of the world must be taught to give up envy, avarice and rancour.",
+		"civilopediaText": [{ "text": "Lasting peace is sought, it is essential to adopt international measures to improve the lot of the masses. The welfare of the entire human race must replace hunger and oppression. People of the world must be taught to give up envy, avarice and rancour."}]
 	},
 	{
 		"name": "Longhouse",
@@ -138,7 +145,8 @@
 			"Can only be built [in capital]",
 			"Gain a free [Salvage Yard] [in this city]"
 		],
-		"quote": "Now there are no doors left in the houses for they have all been kicked off. So, also, there are no fires in the village and have not been for many days. Now the men full of strong drink have trodden in the fireplaces. They alone track there and there are no fires and their footprints are in all the fireplaces."
+		"quote": "Now there are no doors left in the houses for they have all been kicked off. So, also, there are no fires in the village and have not been for many days. Now the men full of strong drink have trodden in the fireplaces. They alone track there and there are no fires and their footprints are in all the fireplaces.",
+		"civilopediaText": [{ "text": "Now there are no doors left in the houses for they have all been kicked off. So, also, there are no fires in the village and have not been for many days. Now the men full of strong drink have trodden in the fireplaces. They alone track there and there are no fires and their footprints are in all the fireplaces."}]
 	},
 	{
 		"name": "The Great Lighthouse",
@@ -152,7 +160,8 @@
 			"Normal vision when embarked <for [All] units>",
 			"[+1] Sight <for [Water] units>"
 		],
-		"quote": "Brightly beams our father's mercy\nFrom his lighthouse evermore\nBut to us he gives the keeping\nOf the lights along the shore."
+		"quote": "Brightly beams our father's mercy\nFrom his lighthouse evermore\nBut to us he gives the keeping\nOf the lights along the shore.",
+		"civilopediaText": [{ "text": "Brightly beams our father's mercy\nFrom his lighthouse evermore\nBut to us he gives the keeping\nOf the lights along the shore."}]
 	},
 	{
 		"name": "Great Mosque",
@@ -169,7 +178,8 @@
 			"Free [Panther] appears",
 			"Gain a free [Mosque] [in this city]"
 		],
-		"quote": "We declare our right on this earth to be a human being, to be respected as a human being, to be given the rights of a human being in this society, on this earth, in this day, which we intend to bring into existence by any means necessary."
+		"quote": "We declare our right on this earth to be a human being, to be respected as a human being, to be given the rights of a human being in this society, on this earth, in this day, which we intend to bring into existence by any means necessary.",
+		"civilopediaText": [{ "text": "We declare our right on this earth to be a human being, to be respected as a human being, to be given the rights of a human being in this society, on this earth, in this day, which we intend to bring into existence by any means necessary."}]
 	},
 	{
 		"name": "Clan Hideout",
@@ -183,7 +193,8 @@
 			"[2] free [Clansman] units appear",
 			"Gain a free [Food Store] [in this city]"
 		],
-		"quote": "If you would keep your secret from an enemy, tell it not to a friend."
+		"quote": "If you would keep your secret from an enemy, tell it not to a friend.",
+		"civilopediaText": [{ "text": "If you would keep your secret from an enemy, tell it not to a friend."}]
 	},
 
 	// Cultural victory
@@ -211,10 +222,11 @@
 			"Hidden when [Diplomatic] Victory is disabled",
 			"Triggers a global alert upon build start"
 		],
-		"quote": "United we stand. Divided we fall."
+		"quote": "United we stand. Divided we fall.",
+		"civilopediaText": [{ "text": "United we stand. Divided we fall."}]
 	},
 
-	// Gov buildings
+	// Government buildings
 	{
 		"name": "Congress",
 		"cost": 100,
@@ -223,6 +235,7 @@
 			"[+1 Culture] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
 			"Requires [Search for Survivors]",
+			"Can only be built [in capital]",
 			"Only available <in cities without a [Council]>",
 			"Destroyed when the city is captured"
 		]
@@ -235,6 +248,7 @@
 			"[+10]% growth [in all cities]",
 			"[+5]% Production when constructing [All] buildings [in this city]",
 			"Requires [Search for Survivors]",
+			"Can only be built [in capital]",
 			"Only available <in cities without a [Congress]>",
 			"Destroyed when the city is captured"
 		]
@@ -249,6 +263,7 @@
 			"[+1 Science, +1 Culture] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
 			"Requires [Search for Survivors]",
+			"Can only be built [in capital]",
 			"Only available <in cities without a [Defense Committee]>",
 			"Destroyed when the city is captured"
 		]
@@ -263,6 +278,7 @@
 			"[+15]% Strength <for [All] units> <when fighting in [Friendly Land] tiles>",
 			"[+20]% Production when constructing [Military] units [in all cities]",
 			"Requires [Search for Survivors]",
+			"Can only be built [in capital]",
 			"Only available <in cities without a [Citizens' Assembly]>",
 			"Destroyed when the city is captured"
 		]
@@ -277,6 +293,7 @@
 			"[+1 Culture, +1 Gold] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
 			"Requires [Search for Survivors]",
+			"Can only be built [in capital]",
 			"Only available <in cities without a [Board of Directors]>",
 			"Destroyed when the city is captured"
 		]
@@ -291,6 +308,7 @@
 			"[+1 Gold] from every [Town Hall]",
 			"Cost of purchasing items in cities reduced by [20]%",
 			"Requires [Search for Survivors]",
+			"Can only be built [in capital]",
 			"Only available <in cities without a [Shareholders' Fund]>",
 			"Destroyed when the city is captured"
 		]
@@ -305,6 +323,7 @@
 			"[+1 Science, +1 Gold] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
 			"Requires [Search for Survivors]",
+			"Can only be built [in capital]",
 			"Only available <in cities without a [Think Tank]>",
 			"Destroyed when the city is captured"
 		]
@@ -319,6 +338,7 @@
 			"Production to science conversion in cities increased by 33%",
 			"[+10]% Production when constructing [Science] buildings [in all cities]",
 			"Requires [Search for Survivors]",
+			"Can only be built [in capital]",
 			"Only available <in cities without a [Freedom Foundation]>",
 			"Destroyed when the city is captured"
 		]
@@ -539,14 +559,16 @@
 			"Only available <in cities with a [Aerospace Facility]>"
 		],
 		"requiredTech": "Satellites",
-		"quote": "I must down to the seas again, to the lonely sea and the sky,\nAnd all I ask is a tall ship and a star to steer her by"
+		"quote": "I must down to the seas again, to the lonely sea and the sky,\nAnd all I ask is a tall ship and a star to steer her by.",
+		"civilopediaText": [{ "text": "I must down to the seas again, to the lonely sea and the sky,\nAnd all I ask is a tall ship and a star to steer her by."}]
 	},
 	{
 		"name": "Cryo Project",
 		"isWonder": true,
 		"requiredTech": "Human Genome",
 		"uniques": ["Enables construction of Cryo Vaults"],
-		"quote": "The fact is, these people want to come back to life, and we need them back alive. We can't wait for a better world to come for them. We've got to let them make that better world for all of us."
+		"quote": "The fact is, these people want to come back to life, and we need them back alive. We can't wait for a better world to come for them. We've got to let them make that better world for all of us.",
+		"civilopediaText": [{ "text": "The fact is, these people want to come back to life, and we need them back alive. We can't wait for a better world to come for them. We've got to let them make that better world for all of us."}]
 	},
 
 	// Normal wonders
@@ -559,7 +581,8 @@
 			"[+1] population [in all cities]",
 			"[+2 Food] [in all cities]"
 		],
-		"quote": "When you hear the air attack warning, you and your family must take cover..."
+		"quote": "When you hear the air attack warning, you and your family must take cover...",
+		"civilopediaText": [{ "text": "When you hear the air attack warning, you and your family must take cover..."}]
 	},
 	{
 		"name": "Public Broadcast",
@@ -570,7 +593,8 @@
 			"[+1] population [in all cities]",
 			"Only available <in cities with a [Broadcast Tower]>"
 		],
-		"quote": "When the immediate danger has passed the sirens will sound a steady note. The all clear message will also be given on this wavelength."
+		"quote": "When the immediate danger has passed the sirens will sound a steady note. The all clear message will also be given on this wavelength.",
+		"civilopediaText": [{ "text": "When the immediate danger has passed the sirens will sound a steady note. The all clear message will also be given on this wavelength."}]
 	},
 	{
 		"name": "Skunkworks",
@@ -584,7 +608,8 @@
 			"Free Technology"
 		],
 		"requiredTech": "Decryption",
-		"quote": "Many times a customer would come to the Skunk Works with a request and on a handshake the project would begin, no contracts in place, no official submittal process."
+		"quote": "Many times a customer would come to the Skunk Works with a request and on a handshake the project would begin, no contracts in place, no official submittal process.",
+		"civilopediaText": [{ "text": "Many times a customer would come to the Skunk Works with a request and on a handshake the project would begin, no contracts in place, no official submittal process."}]
 	},
 	{
 		"name": "Supercollider",
@@ -598,7 +623,8 @@
 		],
 		"percentStatBonus": { "science": 50 },
 		"requiredTech": "Particle Physics",
-		"quote": "God does not play dice."
+		"quote": "God does not play dice.",
+		"civilopediaText": [{ "text": "God does not play dice."}]
 	},
 	{
 		"name": "AI Project",
@@ -614,7 +640,54 @@
 		],
 		"percentStatBonus": { "science": 50 },
 		"requiredTech": "Artificial Intelligence",
-		"quote": "Let there be light."
+		"quote": "Let there be light.",
+		"civilopediaText": [{ "text": "Let there be light."}]
+	},
+
+	// Domination wonders
+	{
+		"name": "Salvage Tank Depot",
+		"requiredTech": "Engineering",
+		"isWonder": true,
+		"cost": 75,
+		"science": 1,
+		"production": -3,
+		"uniques": [
+			"Free [Modern Armor] appears",
+			"Only available <in cities with a [Alma Tank Depot]>"
+		],
+		"quote": "To a man with a hammer, everything looks like a nail.",
+		"civilopediaText": [{ "text": "To a man with a hammer, everything looks like a nail."}]
+	},
+	{
+		"name": "Salvage Bomber",
+		"requiredTech": "Manufacturing",
+		"isWonder": true,
+		"cost": 60,
+		"science": 1,
+		"production": -3,
+		"uniques": [
+			"Free [Bomber] appears",
+			"Only available <in cities with a [Alma Air Base]>",
+			"Only available <in cities without a [Salvage Helicopter]>"
+		],
+		"quote": "For once you have tasted flight, you will forever walk the earth with your eyes turned skyward. For there you have been, and there you will always long to return.",
+		"civilopediaText": [{ "text": "For once you have tasted flight, you will forever walk the earth with your eyes turned skyward. For there you have been, and there you will always long to return."}]
+	},
+	{
+		"name": "Salvage Helicopter",
+		"requiredTech": "Engineering",
+		"isWonder": true,
+		"cost": 75,
+		"science": 1,
+		"production": -3,
+		"uniques": [
+			"Free [Helicopter] appears",
+			"Only available <in cities with a [Alma Air Base]>",
+			"Only available <in cities without a [Salvage Bomber]>"
+		],
+		"quote": "Helicopters don't fly, they vibrate so badly the ground rejects them.",
+		"civilopediaText": [{ "text": "Helicopters don't fly, they vibrate so badly the ground rejects them."}]
 	},
 
 	// Natural Wonder uniques
@@ -653,7 +726,8 @@
 			"Provides [1] [Uranium]"
 		],
 		// "requiredTech": "Secrets of the Past",
-		"quote": "Our legends tell of weapons, wielded by kings of old; crafted by evil wizards, unholy to behold..."
+		"quote": "Our legends tell of weapons, wielded by kings of old; crafted by evil wizards, unholy to behold...",
+		"civilopediaText": [{ "text": "Our legends tell of weapons, wielded by kings of old; crafted by evil wizards, unholy to behold..."}]
 	},
 	{
 		"name": "Nuclear Waste Museum",
@@ -670,13 +744,16 @@
 		"percentStatBonus": { "food": -20 },
 		"requiredTech": "Mining",
 		"uniques": [
-			"DO NOT DO THIS",
 			"Must have an owned [Nuclear Waste Storage] within [3] tiles",
 			"[-3 Food, +4 Science] from [Nuclear Waste Storage] tiles [in this city]",
 			"Provides [1] [Uranium]",
 			"Only available <in cities without a [Nuclear Waste Museum]>"
 		],
-		"quote": "Sending this message was important to us.\nWe considered ourselves to be a powerful culture.\nThis place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.\nWhat is here was dangerous and repulsive to us.\nThis message is a warning about danger.\nThe danger is still present, in your time, as it was in ours."
+		"quote": "Sending this message was important to us.\nWe considered ourselves to be a powerful culture.\nThis place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.\nWhat is here was dangerous and repulsive to us.\nThis message is a warning about danger.\nThe danger is still present, in your time, as it was in ours.",
+		"civilopediaText": [
+			{ "text": "DO NOT DO THIS", "color": "#FF0000" },
+			{ "text": "Sending this message was important to us.\nWe considered ourselves to be a powerful culture.\nThis place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.\nWhat is here was dangerous and repulsive to us.\nThis message is a warning about danger.\nThe danger is still present, in your time, as it was in ours."}
+		]
 	},
 	{
 		"name": "Propagate Seeds", // could give seeds resource? so other nations benefit?
@@ -689,7 +766,8 @@
 			"[+2 Food] [in all cities]",
 			"[+25]% growth [in all cities]"
 		],
-		"quote": "What about us? What about all the plans that ended in disaster?"
+		"quote": "What about us? What about all the plans that ended in disaster?",
+		"civilopediaText": [{ "text": "What about us? What about all the plans that ended in disaster?"}]
 	},
 	{
 		"name": "Distribute Soft Drinks",
@@ -701,7 +779,8 @@
 			"[-1 Culture, -1 Happiness] from [Soft Drinks Factory] tiles [in this city]",
 			"Only available <in cities without a [Produce Soft Drinks]>"
 		],
-		"quote": "E-NERGY ULTRA BRIGHT ZERO EMISSION STEALTH\n(Per 500ml Energy 11kCal(1%**)\nNiacin 43mg(266%**)\nPANTHOTENIC ACID 21mg (350%**)\nCaffeine-B 150mg (600%**)**%RDA)\nZERO SUGAR - JUST AS PUMPED!\nIn collaboration with Gearheads, Musicians, Coders, CEOs, Anarchists, Bikers, Historical Reenactors, Hipsters, and YOU!"
+		"quote": "E-NERGY ULTRA BRIGHT ZERO EMISSION STEALTH\n(Per 500ml Energy 11kCal(1%**)\nNiacin 43mg(266%**)\nPANTHOTENIC ACID 21mg (350%**)\nCaffeine-B 150mg (600%**)**%RDA)\nZERO SUGAR - JUST AS PUMPED!\nIn collaboration with Gearheads, Musicians, Coders, CEOs, Anarchists, Bikers, Historical Reenactors, Hipsters, and YOU!",
+		"civilopediaText": [{ "text": "E-NERGY ULTRA BRIGHT ZERO EMISSION STEALTH\n(Per 500ml Energy 11kCal(1%**)\nNiacin 43mg(266%**)\nPANTHOTENIC ACID 21mg (350%**)\nCaffeine-B 150mg (600%**)**%RDA)\nZERO SUGAR - JUST AS PUMPED!\nIn collaboration with Gearheads, Musicians, Coders, CEOs, Anarchists, Bikers, Historical Reenactors, Hipsters, and YOU!"}]
 	},
 	{
 		"name": "Produce Soft Drinks",
@@ -726,7 +805,8 @@
 			"Provides [1] [Oil]",
 			"Free [Modern Armor] appears"
 		],
-		"quote": "Oh, see the fire is sweepin, our very street today; burns like a red coat carpet, mad bull lost your way.. War, children! It's just a shot away!" // - Traditional nursery rhyme
+		"quote": "Oh, see the fire is sweepin, our very street today; burns like a red coat carpet, mad bull lost your way.. War, children! It's just a shot away!", // - Traditional nursery rhyme
+		"civilopediaText": [{ "text": "Oh, see the fire is sweepin, our very street today; burns like a red coat carpet, mad bull lost your way.. War, children! It's just a shot away!"}]
 	},
 	{
 		"name": "Salvage Graveyard",
@@ -739,7 +819,8 @@
 			"Provides [1] [Oil]",
 			"Free [Patrol Boat] appears"
 		],
-		"quote": "He who commands the sea has command of everything."
+		"quote": "He who commands the sea has command of everything.",
+		"civilopediaText": [{ "text": "He who commands the sea has command of everything."}]
 	},
 	{
 		"name": "Turbine Hall",
@@ -749,7 +830,8 @@
 			"Must have an owned [Hydroelectric Dam] within [3] tiles",
 			"Provides [8] [Power]"
 		],
-		"quote": "At full capacity, these turbines were able to provide clean electricity for 31,052 homes, offsetting up to 51,997 tons of CO2 each year." // - Promotional material
+		"quote": "At full capacity, these turbines were able to provide clean electricity for 31,052 homes, offsetting up to 51,997 tons of CO2 each year.", // - Promotional material
+		"civilopediaText": [{ "text": "At full capacity, these turbines were able to provide clean electricity for 31,052 homes, offsetting up to 51,997 tons of CO2 each year."}]
 	},
 	{
 		"name": "Secret Laboratory",
@@ -771,7 +853,8 @@
 			"Must have an owned [Vault of Records] within [3] tiles",
 			"Hidden when religion is disabled"
 		],
-		"quote": "And I seal up these records, after I have spoken a few words by way of exhortation unto you."
+		"quote": "And I seal up these records, after I have spoken a few words by way of exhortation unto you.",
+		"civilopediaText": [{ "text": "And I seal up these records, after I have spoken a few words by way of exhortation unto you."}]
 	},
 	{
 		"name": "Chemical Weapons Laboratory",
@@ -2595,47 +2678,6 @@
 		"replaces": "Town Hall",
 		"uniqueTo": "Almaty",
 		"requiredTech": "Manufacturing"
-	},
-	{
-		"name": "Salvage Tank Depot",
-		"requiredTech": "Engineering",
-		"isWonder": true,
-		"cost": 75,
-		"science": 1,
-		"production": -3,
-		"uniques": [
-			"Free [Modern Armor] appears",
-			"Only available <in cities with a [Alma Tank Depot]>"
-		],
-		"quote": "To a man with a hammer, everything looks like a nail."
-	},
-	{
-		"name": "Salvage Bomber",
-		"requiredTech": "Manufacturing",
-		"isWonder": true,
-		"cost": 60,
-		"science": 1,
-		"production": -3,
-		"uniques": [
-			"Free [Bomber] appears",
-			"Only available <in cities with a [Alma Air Base]>",
-			"Only available <in cities without a [Salvage Helicopter]>"
-		],
-		"quote": "For once you have tasted flight, you will forever walk the earth with your eyes turned skyward. For there you have been, and there you will always long to return."
-	},
-	{
-		"name": "Salvage Helicopter",
-		"requiredTech": "Engineering",
-		"isWonder": true,
-		"cost": 75,
-		"science": 1,
-		"production": -3,
-		"uniques": [
-			"Free [Helicopter] appears",
-			"Only available <in cities with a [Alma Air Base]>",
-			"Only available <in cities without a [Salvage Bomber]>"
-		],
-		"quote": "Helicopters don't fly, they vibrate so badly the ground rejects them."
 	},
 	{
 		"name": "Hub Monument",

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -1,5 +1,5 @@
 [
-	// capital uniques
+	// Capital uniques
 	{
 		"name": "Bomb Shelter",
 		"isNationalWonder": true,
@@ -12,19 +12,21 @@
 		"culture": 1,
 		"cost": 1,
 		"uniques": ["Indicates the capital city"]
-	},		
+	},
 	{
 		"name": "Stockpile",
 		"isWonder": true,
 		"uniqueTo": "Enclavers",
 		"cost": 1,
-		"uniques": ["[10]% Food is carried over after population increases [in this city]",
+		"uniques": [
+			"[10]% Food is carried over after population increases [in this city]",
 			"Provides [2] [Weapons]",
 			"Free [Guerilla] appears",
 			"Can only be built [in capital]",
-			"Gain a free [Deep Larder] [in this city]"],
+			"Gain a free [Deep Larder] [in this city]"
+		],
 		"quote": "An armed society is a polite society."
-	},		
+	},
 	{
 		"name": "Ark One",
 		"isWonder": true,
@@ -35,78 +37,90 @@
 		"cityStrength": 10,
 		"cityHealth": 60,
 		"cost": 1,
-		"uniques": ["Provides [1] [Power]",
+		"uniques": [
+			"Provides [1] [Power]",
 			"Free [Security] appears",
 			"Can only be built [in capital]",
-			"Gain a free [Food Store] [in this city]"],
-		"quote":"While your deposit clears, you may want to read through this guide for potential residents. The Ark One shelter comprises a unique set of secure luxury accomodation based within a former military facility. In addition to their private living space, residents will have access to a complete set of facilities including two restaurants, a cinema, a bowling alley, and a fitness area with gym, spa, sauna and pool. The Ark One shelter is protected by a world-class professional security company, and is hardened to resist a nuclear strike and any armed attack."
+			"Gain a free [Food Store] [in this city]"
+		],
+		"quote": "While your deposit clears, you may want to read through this guide for potential residents. The Ark One shelter comprises a unique set of secure luxury accomodation based within a former military facility. In addition to their private living space, residents will have access to a complete set of facilities including two restaurants, a cinema, a bowling alley, and a fitness area with gym, spa, sauna and pool. The Ark One shelter is protected by a world-class professional security company, and is hardened to resist a nuclear strike and any armed attack."
 	},
 	{
 		"name": "Atlas Refuge",
 		"isWonder": true,
 		"uniqueTo": "Atlas",
-		"specialistSlots": {"Scientist": 1},
+		"specialistSlots": { "Scientist": 1 },
 		"gold": 1,
 		"cityHealth": 40,
 		"cost": 1,
-		"uniques": ["Provides [1] [Power]",
+		"uniques": [
+			"Provides [1] [Power]",
 			"[2] free [Surveyor] units appear",
 			"Can only be built [in capital]",
-			"Gain a free [Food Store] [in this city]"],
-		"quote":"At the Refuge, I am creating more than a town, more even than a polity; it is a new world, where individuals will be free to act without the burden of taxation or the specter of injustice. Here, I have created a truly voluntary society, where the citizens associate in rational self interest; from love, not from fear of punishment. I have sent you this invitation because you have greatness within you; think of all you have achieved in your life, and how much more you could do, if you were not held back. Choose something different. Choose Atlas."
+			"Gain a free [Food Store] [in this city]"
+		],
+		"quote": "At the Refuge, I am creating more than a town, more even than a polity; it is a new world, where individuals will be free to act without the burden of taxation or the specter of injustice. Here, I have created a truly voluntary society, where the citizens associate in rational self interest; from love, not from fear of punishment. I have sent you this invitation because you have greatness within you; think of all you have achieved in your life, and how much more you could do, if you were not held back. Choose something different. Choose Atlas."
 	},
 	{
 		"name": "Eagle Rock Complex",
 		"isWonder": true,
 		"uniqueTo": "The Patriots",
-		"specialistSlots": {"Engineer": 1},
+		"specialistSlots": { "Engineer": 1 },
 		"gold": 1,
 		"cityStrength": 20,
 		"cityHealth": 80,
 		"cost": 1,
-		"uniques": ["[10]% Food is carried over after population increases [in this city]",
+		"uniques": [
+			"[10]% Food is carried over after population increases [in this city]",
 			"Provides [1] [Power]",
 			"Provides [2] [Weapons]",
 			"Free [Spec Ops] appears",
 			"Can only be built [in capital]",
-			"Gain a free [Food Store] [in this city]"],
+			"Gain a free [Food Store] [in this city]"
+		],
 		"quote": "We are here to protect the people, and we will do it here. Here we make our stand against anarchy and tyranny. Here, we will once again establish freedom and order. This is the oath we have taken, and we will keep that oath."
-	},	
+	},
 	{
 		"name": "Forum",
 		"isWonder": true,
 		"uniqueTo": "Crimson Legion",
 		"cityHealth": 20,
 		"cost": 1,
-		"uniques": ["[-10]% unhappiness from population [in all cities]",
+		"uniques": [
+			"[-10]% unhappiness from population [in all cities]",
 			"Free [Swordsman] appears",
-			"Can only be built [in capital]"],
+			"Can only be built [in capital]"
+		],
 		"quote": "Whatsoever any man either doth or saith, thou must be good; not for any man's sake, but for thine own nature's sake; as if either gold, or the emerald, or purple, should ever be saying to themselves, Whatsoever any man either doth or saith, I must still be an emerald, and I must keep my colour."
 	},
 	{
 		"name": "Temple",
 		"isWonder": true,
 		"uniqueTo": "Cult of Ignis",
-		"specialistSlots": {"Administrator": 1},
+		"specialistSlots": { "Administrator": 1 },
 		"happiness": 1,
 		"cost": 1,
-		"uniques": ["[+2 Culture] <after discovering [Iron Working]>",
+		"uniques": [
+			"[+2 Culture] <after discovering [Iron Working]>",
 			"Provides [2] [Oil]",
 			"Free [War Buggy] appears",
 			"Can only be built [in capital]",
-			"Gain a free [Fuel Depot] [in this city]"],
-		"quote":"Be thy hands, anointed, with holy oil.\nBe thy breast, anointed, with holy oil.\nBe thy head, anointed, with holy oil.\nAs kings, priests, and prophets were anointed.\nAnd as Solomon was anointed king by Zadok the priest and Nathan the prophet, so be you anointed."			
+			"Gain a free [Fuel Depot] [in this city]"
+		],
+		"quote": "Be thy hands, anointed, with holy oil.\nBe thy breast, anointed, with holy oil.\nBe thy head, anointed, with holy oil.\nAs kings, priests, and prophets were anointed.\nAnd as Solomon was anointed king by Zadok the priest and Nathan the prophet, so be you anointed."
 	},
 	{
 		"name": "Peace Memorial",
 		"isWonder": true,
 		"uniqueTo": "Commonwealth",
 		"cost": 1,
-		"uniques": ["[+25]% great person generation [in this city]",
+		"uniques": [
+			"[+25]% great person generation [in this city]",
 			"City-State territory always counts as friendly territory",
 			"Free [Ranger] appears",
 			"Can only be built [in capital]",
-			"Gain a free [Monument] [in this city]"],
+			"Gain a free [Monument] [in this city]"
+		],
 		"quote": "Lasting peace is sought, it is essential to adopt international measures to improve the lot of the masses. The welfare of the entire human race must replace hunger and oppression. People of the world must be taught to give up envy, avarice and rancour."
 	},
 	{
@@ -116,12 +130,14 @@
 		"cost": 1,
 		"cityStrength": 1,
 		"cityHealth": 10,
-		"uniques": ["[+1 Culture] from [Forest] tiles [in this city]",
+		"uniques": [
+			"[+1 Culture] from [Forest] tiles [in this city]",
 			"[+1 Culture] from [Jungle] tiles [in this city]",
 			"[+1 Culture] from [Sunken Ruins] tiles [in this city]",
 			"[2] free [Scavenger] units appear",
 			"Can only be built [in capital]",
-			"Gain a free [Salvage Yard] [in this city]"],
+			"Gain a free [Salvage Yard] [in this city]"
+		],
 		"quote": "Now there are no doors left in the houses for they have all been kicked off. So, also, there are no fires in the village and have not been for many days. Now the men full of strong drink have trodden in the fireplaces. They alone track there and there are no fires and their footprints are in all the fireplaces."
 	},
 	{
@@ -129,11 +145,13 @@
 		"isWonder": true,
 		"uniqueTo": "The Mariners",
 		"cost": 1,
-		"uniques": ["Must be next to [Coast]",
+		"uniques": [
+			"Must be next to [Coast]",
 			"[2] free [Trimaran] units appear",
 			"Gain a free [Lighthouse] [in this city]",
 			"Normal vision when embarked <for [All] units>",
-			"[+1] Sight <for [Water] units>"],
+			"[+1] Sight <for [Water] units>"
+		],
 		"quote": "Brightly beams our father's mercy\nFrom his lighthouse evermore\nBut to us he gives the keeping\nOf the lights along the shore."
 	},
 	{
@@ -145,10 +163,12 @@
 		"food": 2,
 		"cityStrength": 1,
 		"cityHealth": 10,
-		"uniques": ["Can only be built [in capital]",
+		"uniques": [
+			"Can only be built [in capital]",
 			"Provides [1] [Weapons]",
 			"Free [Panther] appears",
-			"Gain a free [Mosque] [in this city]"],
+			"Gain a free [Mosque] [in this city]"
+		],
 		"quote": "We declare our right on this earth to be a human being, to be respected as a human being, to be given the rights of a human being in this society, on this earth, in this day, which we intend to bring into existence by any means necessary."
 	},
 	{
@@ -157,156 +177,180 @@
 		"uniqueTo": "Deadrock Clan",
 		"cost": 1,
 		"cityHealth": 10,
-		"uniques": ["Can only be built [in capital]",
+		"uniques": [
+			"Can only be built [in capital]",
 			"Provides [1] [Weapons]",
 			"[2] free [Clansman] units appear",
-			"Gain a free [Food Store] [in this city]"],
+			"Gain a free [Food Store] [in this city]"
+		],
 		"quote": "If you would keep your secret from an enemy, tell it not to a friend."
 	},
 
-
-	//Cultural victory
+	// Cultural victory
 	{
 		"name": "Utopia Project",
 		"cost": 1500,
 		"isNationalWonder": true,
-		"uniques": ["Hidden until [5] social policy branches have been completed",
-			"Triggers a global alert upon build start", 
+		"uniques": [
+			"Hidden until [5] social policy branches have been completed",
+			"Triggers a global alert upon build start",
 			"Triggers a Cultural Victory upon completion",
-			"Hidden when [Cultural] Victory is disabled"]
+			"Hidden when [Cultural] Victory is disabled"
+		]
 	},
 
-	//Diplomatic victory
+	// Diplomatic victory
 	{
 		"name": "United Nations",
 		"isWonder": true,
 		"culture": 1,
-		"greatPersonPoints": {"Great Merchant": 2},
+		"greatPersonPoints": { "Great Merchant": 2 },
 		"requiredTech": "Globalization",
-		"uniques": ["Triggers voting for the Diplomatic Victory",
+		"uniques": [
+			"Triggers voting for the Diplomatic Victory",
 			"Hidden when [Diplomatic] Victory is disabled",
-			"Triggers a global alert upon build start"],
+			"Triggers a global alert upon build start"
+		],
 		"quote": "United we stand. Divided we fall."
 	},
-	
-	//gov buildings
-	
+
+	// Gov buildings
 	{
 		"name": "Congress",
 		"cost": 100,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+1 Culture] per [4] population [in all cities]",
+		"uniques": [
+			"[+1 Culture] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
 			"Requires [Search for Survivors]",
 			"Only available <in cities without a [Council]>",
-			"Destroyed when the city is captured"]
-	},		
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Council",
 		"cost": 50,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+10]% growth [in all cities]",
+		"uniques": [
+			"[+10]% growth [in all cities]",
 			"[+5]% Production when constructing [All] buildings [in this city]",
 			"Requires [Search for Survivors]",
 			"Only available <in cities without a [Congress]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Citizens' Assembly",
 		"replaces": "Congress",
 		"uniqueTo": "Children of Rust",
 		"cost": 50,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+1 Science, +1 Culture] per [4] population [in all cities]",
+		"uniques": [
+			"[+1 Science, +1 Culture] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
 			"Requires [Search for Survivors]",
 			"Only available <in cities without a [Defense Committee]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Defense Committee",
 		"replaces": "Council",
 		"uniqueTo": "Children of Rust",
 		"cost": 50,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+15]% Strength <for [All] units> <when fighting in [Friendly Land] tiles>",
+		"uniques": [
+			"[+15]% Strength <for [All] units> <when fighting in [Friendly Land] tiles>",
 			"[+20]% Production when constructing [Military] units [in all cities]",
 			"Requires [Search for Survivors]",
 			"Only available <in cities without a [Citizens' Assembly]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Shareholders' Fund",
 		"replaces": "Congress",
 		"uniqueTo": "Blackwarden",
 		"cost": 100,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+1 Culture, +1 Gold] per [4] population [in all cities]",
+		"uniques": [
+			"[+1 Culture, +1 Gold] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
 			"Requires [Search for Survivors]",
 			"Only available <in cities without a [Board of Directors]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Board of Directors",
 		"replaces": "Council",
 		"uniqueTo": "Blackwarden",
 		"cost": 50,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+1 Gold] from every [Town Hall]",
+		"uniques": [
+			"[+1 Gold] from every [Town Hall]",
 			"Cost of purchasing items in cities reduced by [20]%",
 			"Requires [Search for Survivors]",
 			"Only available <in cities without a [Shareholders' Fund]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Freedom Foundation",
 		"replaces": "Congress",
 		"uniqueTo": "Atlas",
 		"cost": 100,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+1 Science, +1 Gold] per [4] population [in all cities]",
+		"uniques": [
+			"[+1 Science, +1 Gold] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
 			"Requires [Search for Survivors]",
 			"Only available <in cities without a [Think Tank]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Think Tank",
 		"replaces": "Council",
 		"uniqueTo": "Atlas",
 		"cost": 50,
 		"requiredTech": "Civil Service",
-		"uniques": ["Production to science conversion in cities increased by 33%",
+		"uniques": [
+			"Production to science conversion in cities increased by 33%",
 			"[+10]% Production when constructing [Science] buildings [in all cities]",
 			"Requires [Search for Survivors]",
 			"Only available <in cities without a [Freedom Foundation]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Smugglers' Guild",
 		"replaces": "Congress",
 		"uniqueTo": "Deadrock Clan",
 		"cost": 100,
 		"requiredTech": "Currency",
-		"uniques": ["Provides a sum of gold each time you spend a Great Person",
+		"uniques": [
+			"Provides a sum of gold each time you spend a Great Person",
 			"[Great Merchant] is earned [25]% faster",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Grand Clan Manor]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Grand Clan Manor",
 		"replaces": "Council",
 		"uniqueTo": "Deadrock Clan",
 		"cost": 200,
 		"requiredTech": "Currency",
-		"uniques": ["Can produce Black Hand infantry",
+		"uniques": [
+			"Can produce Black Hand infantry",
 			"[Great General] is earned [50]% faster",
 			"New [Clansman] units start with [30] Experience [in all cities]",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Smugglers' Guild]>",
-			"Destroyed when the city is captured"]
+			"Destroyed when the city is captured"
+		]
 	},
 	{
 		"name": "Senate",
@@ -314,23 +358,27 @@
 		"uniqueTo": "Crimson Legion",
 		"cost": 100,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+1 Culture, +1 Gold] per [4] population [in all cities]",
+		"uniques": [
+			"[+1 Culture, +1 Gold] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Consulate]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Consulate",
 		"replaces": "Council",
 		"uniqueTo": "Crimson Legion",
 		"cost": 50,
 		"requiredTech": "Civil Service",
-		"uniques": ["Great General provides double combat bonus",
+		"uniques": [
+			"Great General provides double combat bonus",
 			"[+20]% Production when constructing [Military] units [in all cities]",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Senate]>",
-			"Destroyed when the city is captured"]
+			"Destroyed when the city is captured"
+		]
 	},
 	{
 		"name": "War Council",
@@ -338,389 +386,515 @@
 		"uniqueTo": "Cult of Ignis",
 		"cost": 50,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+1 Production] per [4] population [in all cities]",
+		"uniques": [
+			"[+1 Production] per [4] population [in all cities]",
 			"[+20]% Production when constructing [Military] units [in all cities]",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Seer Council]>",
-			"Destroyed when the city is captured"]
-	},	
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Seer Council",
 		"replaces": "Council",
 		"uniqueTo": "Cult of Ignis",
 		"cost": 100,
 		"requiredTech": "Civil Service",
-		"uniques": ["[+25]% [Science] from every [College of Mystics]",
+		"uniques": [
+			"[+25]% [Science] from every [College of Mystics]",
 			"[+20]% Production when constructing [Science] buildings [in this city]",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [War Council]>",
-			"Destroyed when the city is captured"]
+			"Destroyed when the city is captured"
+		]
 	},
-	
-	//END capital uniques
-	
+
+	// Science victory
 	{
 		"name": "Biosphere Project",
 		"cost": 1500,
 		"isNationalWonder": true,
-		"uniques": ["Enables construction of Spaceship parts",
+		"uniques": [
+			"Enables construction of Spaceship parts",
 			"Triggers a global alert upon completion",
-			"Hidden when [Scientific] Victory is disabled"],
+			"Hidden when [Scientific] Victory is disabled"
+		],
 		"requiredTech": "Plastics Recycling"
-	},	
-	{
-		"name": "Manhattan Project",
-		"isNationalWonder": true,
-		"uniques": ["Enables nuclear weapon",
-			"Triggers a global alert upon completion"],
-		"requiredTech": "Nuclear Fission"
 	},
-		{
-		"name": "SS Booster", //solar shade
+	{
+		"name": "SS Booster", // Solar Shade
 		"requiredTech": "Future Materials",
-		"uniques": ["Consumes [1] [Aluminum]",
+		"uniques": [
+			"Consumes [1] [Aluminum]",
 			"Spaceship part",
 			"Cannot be purchased",
 			"Triggers a global alert upon completion",
-			"Hidden when [Scientific] Victory is disabled"]
+			"Hidden when [Scientific] Victory is disabled"
+		]
 	},
 	{
-		"name": "SS Cockpit", //command center
+		"name": "SS Cockpit", // Command Center
 		"requiredTech": "Artificial Intelligence",
-		"uniques": ["Consumes [1] [Aluminum]",
+		"uniques": [
+			"Consumes [1] [Aluminum]",
 			"Spaceship part",
 			"Cannot be purchased",
 			"Triggers a global alert upon completion",
-			"Hidden when [Scientific] Victory is disabled"]
+			"Hidden when [Scientific] Victory is disabled"
+		]
 	},
 	{
-		"name": "SS Engine", //ocean processor
+		"name": "SS Engine", // Ocean Processor
 		"requiredTech": "Future Power",
-		"uniques": ["Consumes [1] [Uranium]",
+		"uniques": [
+			"Consumes [1] [Uranium]",
 			"Spaceship part",
 			"Only available <in cities with a [Harbor]>",
 			"Cannot be purchased",
 			"Triggers a global alert upon completion",
-			"Hidden when [Scientific] Victory is disabled"]
+			"Hidden when [Scientific] Victory is disabled"
+		]
 	},
 	{
-		"name": "SS Stasis Chamber", //atmosphere processor
+		"name": "SS Stasis Chamber", // Atmosphere Processor
 		"requiredTech": "Geo Engineering",
-		"uniques": ["Consumes [1] [Uranium]",
+		"uniques": [
+			"Consumes [1] [Uranium]",
 			"Spaceship part",
 			"Cannot be purchased",
 			"Triggers a global alert upon completion",
-			"Hidden when [Scientific] Victory is disabled"]
+			"Hidden when [Scientific] Victory is disabled"
+		]
 	},
-		
-	// projects
-	
+
+	// Projects
 	{
 		"name": "Search for Survivors",
-        "cost": 30,
+		"cost": 30,
 		"isNationalWonder": true,
-		"uniques": ["[+1] population [in all cities]",
-			"Free [Civilian Convoy] appears"]
-	},		
+		"uniques": [
+			"[+1] population [in all cities]",
+			"Free [Civilian Convoy] appears"
+		]
+	},
 	{
 		"name": "Shake Down Survivors",
-        "cost": 5,
+		"cost": 5,
 		"isNationalWonder": true,
 		"replaces": "Search for Survivors",
 		"uniqueTo": "Deadrock Clan",
 		"uniques": ["Provides [2] [Slaves]"]
-	},		
+	},
 	{
 		"name": "Slaver Guild",
-        "cost": 40,
+		"cost": 40,
 		"isNationalWonder": true,
-		"percentStatBonus": {"production": 10},
+		"percentStatBonus": { "production": 10 },
 		"replaces": "Search for Survivors",
 		"uniqueTo": "Crimson Legion",
-		"uniques": ["[+1 Happiness] [in all cities connected to capital]",
+		"uniques": [
+			"[+1 Happiness] [in all cities connected to capital]",
 			"Provides [3] [Slaves]",
 			"[+50]% Production when constructing [Worker] units [in all cities]",
-			"Free [Auxiliary] appears"]
-	},		
+			"Free [Auxiliary] appears"
+		]
+	},
 	{
 		"name": "Conscript Survivors",
-        "cost": 25,
+		"cost": 25,
 		"replaces": "Search for Survivors",
 		"uniqueTo": "Cult of Ignis",
 		"isNationalWonder": true,
-		"uniques": ["Provides [3] [Slaves]",
-			"Free [Warrior] appears"]
-	},	
-	{
-		"name": "Search Shelters",
-        "cost": 75,
-		"isWonder": true,	
-		"requiredTech": "Secrets of the Past",
-		"uniques": ["[+1] population [in all cities]",
-			"[+2 Food] [in all cities]"],
-		"quote": "When you hear the air attack warning, you and your family must take cover..."
-	},			
+		"uniques": ["Provides [3] [Slaves]", "Free [Warrior] appears"]
+	},
 	{
 		"name": "Heavy Equipment",
 		"isNationalWonder": true,
 		"requiredTech": "Engineering",
-		"requiredNearbyImprovedResources": ["Oil","Coal","Aluminum"],
-		"uniques": ["[-25]% tile improvement construction time",
-			"Free [Worker] appears"]
+		"requiredNearbyImprovedResources": ["Oil", "Coal", "Aluminum"],
+		"uniques": [
+			"[-25]% tile improvement construction time",
+			"Free [Worker] appears"
+		]
+	},
+	{
+		"name": "Manhattan Project",
+		"isNationalWonder": true,
+		"requiredTech": "Nuclear Fission",
+		"uniques": [
+			"Enables nuclear weapon",
+			"Triggers a global alert upon completion"
+		]
+	},
+	{
+		"name": "Satnav Network",
+		"science": 1,
+		"greatPersonPoints": { "Great Engineer": 2 },
+		"isWonder": true,
+		"uniques": [
+			"Gold from all trade routes +25%",
+			"[+1] Movement <for [All] units>",
+			"[+1] Sight <for [All] units>",
+			"Reveals the entire map",
+			"Only available <in cities with a [Aerospace Facility]>"
+		],
+		"requiredTech": "Satellites",
+		"quote": "I must down to the seas again, to the lonely sea and the sky,\nAnd all I ask is a tall ship and a star to steer her by"
+	},
+	{
+		"name": "Cryo Project",
+		"isWonder": true,
+		"requiredTech": "Human Genome",
+		"uniques": ["Enables construction of Cryo Vaults"],
+		"quote": "The fact is, these people want to come back to life, and we need them back alive. We can't wait for a better world to come for them. We've got to let them make that better world for all of us."
+	},
+
+	// Normal wonders
+	{
+		"name": "Search Shelters",
+		"cost": 75,
+		"isWonder": true,
+		"requiredTech": "Secrets of the Past",
+		"uniques": [
+			"[+1] population [in all cities]",
+			"[+2 Food] [in all cities]"
+		],
+		"quote": "When you hear the air attack warning, you and your family must take cover..."
 	},
 	{
 		"name": "Public Broadcast",
 		"isWonder": true,
 		"cost": 100,
 		"requiredTech": "Radio",
-		"uniques": ["[+1] population [in all cities]",
-			"Only available <in cities with a [Broadcast Tower]>"],
+		"uniques": [
+			"[+1] population [in all cities]",
+			"Only available <in cities with a [Broadcast Tower]>"
+		],
 		"quote": "When the immediate danger has passed the sirens will sound a steady note. The all clear message will also be given on this wavelength."
 	},
-	
-	//Natural Wonder uniques
+	{
+		"name": "Skunkworks",
+		"culture": 1,
+		"greatPersonPoints": { "Great Scientist": 2 },
+		"isWonder": true,
+		"uniques": [
+			"Consumes [1] [Encrypted Data]",
+			"[+3 Science] <with [Power]>",
+			"Only available <in cities with a [Data Center]>",
+			"Free Technology"
+		],
+		"requiredTech": "Decryption",
+		"quote": "Many times a customer would come to the Skunk Works with a request and on a handshake the project would begin, no contracts in place, no official submittal process."
+	},
+	{
+		"name": "Supercollider",
+		"science": 5,
+		"culture": 1,
+		"greatPersonPoints": { "Great Scientist": 2 },
+		"isWonder": true,
+		"uniques": [
+			"[2] free [Great Scientist] units appear",
+			"Consumes [1] [Power]"
+		],
+		"percentStatBonus": { "science": 50 },
+		"requiredTech": "Particle Physics",
+		"quote": "God does not play dice."
+	},
+	{
+		"name": "AI Project",
+		"cost": 3750,
+		"science": 5,
+		"isWonder": true,
+		"uniques": [
+			"[+15]% Strength <for [Automated] units>",
+			"Free [Great Scientist] appears",
+			"Empire enters golden age",
+			"[+15]% Production when constructing [Spaceship part] buildings [in this city]",
+			"Consumes [2] [Power]"
+		],
+		"percentStatBonus": { "science": 50 },
+		"requiredTech": "Artificial Intelligence",
+		"quote": "Let there be light."
+	},
+
+	// Natural Wonder uniques
 	{
 		"name": "Ally with Isolationists",
 		"cost": 5,
-		"uniques": ["Must have an owned [Isolated Island] within [3] tiles",
+		"uniques": [
+			"Must have an owned [Isolated Island] within [3] tiles",
 			"[+2 Science, +2 Gold] from [Isolated Island] tiles [in this city]",
-			"Only available <in cities without a [Annex Isolationists]>"]
-	},	
+			"Only available <in cities without a [Annex Isolationists]>"
+		]
+	},
 	{
 		"name": "Annex Isolationists",
 		"isNationalWonder": true,
 		"requiredTech": "Sailing",
 		"cost": 200,
-		"uniques": ["Must have an owned [Isolated Island] within [3] tiles",
+		"uniques": [
+			"Must have an owned [Isolated Island] within [3] tiles",
 			"[+2 Food, +5 Gold, -1 Culture] from [Isolated Island] tiles [in this city]",
 			"Provides [1] [Weapons]",
 			"Provides [1] [Slaves]",
-			"Only available <in cities without a [Ally with Isolationists]>"]
-		//"quote": "Ephialtes the son of Eurydemos, a Malian, came to speech with him, supposing that he would win a very great reward from the king; and this man told him of the path which leads over the mountain to Thermopylae, and brought about the destruction of those Greeks who remained in that place."
-	},	
+			"Only available <in cities without a [Ally with Isolationists]>"
+		]
+		// "quote": "Ephialtes the son of Eurydemos, a Malian, came to speech with him, supposing that he would win a very great reward from the king; and this man told him of the path which leads over the mountain to Thermopylae, and brought about the destruction of those Greeks who remained in that place."
+	},
 	{
 		"name": "Faust Project",
 		"isWonder": true,
-	//	"requiredBuilding": "Bomb Shelter",		
 		"cost": 125,
-		"uniques": ["Must have an owned [Missile Complex] within [4] tiles",
+		"uniques": [
+			"Must have an owned [Missile Complex] within [4] tiles",
 			"[+20]% Production when constructing [Manhattan Project] wonders [in all cities]",
 			"[+20]% Production when constructing [Missile] units [in all cities]",
 			"Free [Divine Spear] appears",
-			"Provides [1] [Uranium]"],
-	//	"requiredTech": "Secrets of the Past",
+			"Provides [1] [Uranium]"
+		],
+		// "requiredTech": "Secrets of the Past",
 		"quote": "Our legends tell of weapons, wielded by kings of old; crafted by evil wizards, unholy to behold..."
-	},	
+	},
 	{
 		"name": "Nuclear Waste Museum",
 		"requiredTech": "Writing",
-		"uniques": ["Must have an owned [Nuclear Waste Storage] within [3] tiles",
+		"uniques": [
+			"Must have an owned [Nuclear Waste Storage] within [3] tiles",
 			"[+1 Culture, +1 Science] from [Nuclear Waste Storage] tiles [in this city]",
-			"Only available <in cities without a [Excavate Nuclear Waste]>"]
+			"Only available <in cities without a [Excavate Nuclear Waste]>"
+		]
 	},
 	{
 		"name": "Excavate Nuclear Waste",
 		"isWonder": true,
-		"percentStatBonus": {"food": -20},
+		"percentStatBonus": { "food": -20 },
 		"requiredTech": "Mining",
-		"uniques": ["DO NOT DO THIS",
+		"uniques": [
+			"DO NOT DO THIS",
 			"Must have an owned [Nuclear Waste Storage] within [3] tiles",
 			"[-3 Food, +4 Science] from [Nuclear Waste Storage] tiles [in this city]",
 			"Provides [1] [Uranium]",
-			"Only available <in cities without a [Nuclear Waste Museum]>"],
+			"Only available <in cities without a [Nuclear Waste Museum]>"
+		],
 		"quote": "Sending this message was important to us.\nWe considered ourselves to be a powerful culture.\nThis place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.\nWhat is here was dangerous and repulsive to us.\nThis message is a warning about danger.\nThe danger is still present, in your time, as it was in ours."
-},
+	},
 	{
-		"name": "Propagate Seeds", //could give seeds resource? so other nations benefit?
+		"name": "Propagate Seeds", // could give seeds resource? so other nations benefit?
 		"isWonder": true,
 		"requiredTech": "Ecology",
 		"cost": 50,
-		"uniques": ["Must have an owned [Seed Vault] within [3] tiles",
+		"uniques": [
+			"Must have an owned [Seed Vault] within [3] tiles",
 			"Provides [3] [Exotic Seeds]",
 			"[+2 Food] [in all cities]",
-			"[+25]% growth [in all cities]"],
+			"[+25]% growth [in all cities]"
+		],
 		"quote": "What about us? What about all the plans that ended in disaster?"
-	},		
+	},
 	{
 		"name": "Distribute Soft Drinks",
 		"isWonder": true,
 		"cost": 25,
-		"uniques": ["Must have an owned [Soft Drinks Factory] within [3] tiles",
+		"uniques": [
+			"Must have an owned [Soft Drinks Factory] within [3] tiles",
 			"Empire enters golden age",
 			"[-1 Culture, -1 Happiness] from [Soft Drinks Factory] tiles [in this city]",
-			"Only available <in cities without a [Produce Soft Drinks]>"],
+			"Only available <in cities without a [Produce Soft Drinks]>"
+		],
 		"quote": "E-NERGY ULTRA BRIGHT ZERO EMISSION STEALTH\n(Per 500ml Energy 11kCal(1%**)\nNiacin 43mg(266%**)\nPANTHOTENIC ACID 21mg (350%**)\nCaffeine-B 150mg (600%**)**%RDA)\nZERO SUGAR - JUST AS PUMPED!\nIn collaboration with Gearheads, Musicians, Coders, CEOs, Anarchists, Bikers, Historical Reenactors, Hipsters, and YOU!"
-	},	
+	},
 	{
 		"name": "Produce Soft Drinks",
 		"isNationalWonder": true,
 		"requiredTech": "Steam Power",
-		"uniques": ["Must have an owned [Soft Drinks Factory] within [3] tiles",
+		"uniques": [
+			"Must have an owned [Soft Drinks Factory] within [3] tiles",
 			"Provides [3] [Soft Drinks]",
 			"Consumes [1] [Power]",
-			"Only available <in cities without a [Distribute Soft Drinks]>"]
-	},		
+			"Only available <in cities without a [Distribute Soft Drinks]>"
+		]
+	},
 	{
 		"name": "Salvage Army Depot",
 		"requiredTech": "Engineering",
 		"isWonder": true,
 		"cost": 50,
-		"uniques": ["Must have an owned [Army Depot] within [3] tiles",
+		"uniques": [
+			"Must have an owned [Army Depot] within [3] tiles",
 			"[+1 Science, +1 Production] from [Army Depot] tiles [in this city]",
 			"Provides [2] [Weapons]",
 			"Provides [1] [Oil]",
-			"Free [Modern Armor] appears"],
-		"quote": "Oh, see the fire is sweepin, our very street today; burns like a red coat carpet, mad bull lost your way.. War, children! It's just a shot away!"// - Traditional nursery rhyme
+			"Free [Modern Armor] appears"
+		],
+		"quote": "Oh, see the fire is sweepin, our very street today; burns like a red coat carpet, mad bull lost your way.. War, children! It's just a shot away!" // - Traditional nursery rhyme
 	},
 	{
 		"name": "Salvage Graveyard",
 		"requiredTech": "Sailing",
 		"isWonder": true,
 		"cost": 50,
-		"uniques": ["Must have an owned [Ship Graveyard] within [3] tiles",
+		"uniques": [
+			"Must have an owned [Ship Graveyard] within [3] tiles",
 			"[+1 Science, +1 Production] from [Ship Graveyard] tiles [in this city]",
 			"Provides [1] [Oil]",
-			"Free [Patrol Boat] appears"],
+			"Free [Patrol Boat] appears"
+		],
 		"quote": "He who commands the sea has command of everything."
 	},
 	{
 		"name": "Turbine Hall",
 		"isWonder": true,
 		"requiredTech": "Steel",
-		"uniques": ["Must have an owned [Hydroelectric Dam] within [3] tiles",
-			"Provides [8] [Power]"],
-		"quote": "At full capacity, these turbines were able to provide clean electricity for 31,052 homes, offsetting up to 51,997 tons of CO2 each year."// - Promotional material
-	},	
+		"uniques": [
+			"Must have an owned [Hydroelectric Dam] within [3] tiles",
+			"Provides [8] [Power]"
+		],
+		"quote": "At full capacity, these turbines were able to provide clean electricity for 31,052 homes, offsetting up to 51,997 tons of CO2 each year." // - Promotional material
+	},
 	{
 		"name": "Secret Laboratory",
 		"isNationalWonder": true,
 		"requiredTech": "Laboratory",
-		"greatPersonPoints": {"Great Scientist": 2},
-		"uniques": ["Must have an owned [Research Facility] within [5] tiles",
-			"All newly-trained [relevant] units [in this city] receive the [March] promotion"]
+		"greatPersonPoints": { "Great Scientist": 2 },
+		"uniques": [
+			"Must have an owned [Research Facility] within [5] tiles",
+			"All newly-trained [relevant] units [in this city] receive the [March] promotion"
+		]
 	},
 	{
 		"name": "Open the Vault",
 		"isWonder": true,
 		"requiredTech": "Secrets of the Past",
-		"uniques": ["Free [Great Sage] appears",
+		"uniques": [
+			"Free [Great Sage] appears",
 			"[+1 Culture, +1 Faith] from [Vault of Records] tiles [in this city]",
 			"Must have an owned [Vault of Records] within [3] tiles",
-			"Hidden when religion is disabled"],
+			"Hidden when religion is disabled"
+		],
 		"quote": "And I seal up these records, after I have spoken a few words by way of exhortation unto you."
 	},
-		
-		
 	{
 		"name": "Chemical Weapons Laboratory",
 		"isNationalWonder": true,
 		"requiredTech": "Laboratory",
-		"maintenance": 2,	
-		"greatPersonPoints": {"Great Scientist": 1},
-		"uniques": ["Must have an owned [Marsh] within [15] tiles",
+		"maintenance": 2,
+		"greatPersonPoints": { "Great Scientist": 1 },
+		"uniques": [
+			"Must have an owned [Marsh] within [15] tiles",
 			"Requires [Supremacy]",
 			"[Siege] units gain the [Chemical Weapons] promotion",
 			"[Air] units gain the [Chemical Weapons] promotion",
 			"[Helicopter] units gain the [Chemical Weapons] promotion",
-			"Consumes [1] [Power]"]
+			"Consumes [1] [Power]"
+		]
 	},
-		//	FOOD
-	
+
+	// Food buildings
 	{
-		"name": "Food Store", 
+		"name": "Food Store",
 		"cost": 10,
 		"hurryCostModifier": -25,
-		"uniques": ["[20]% Food is carried over after population increases [in this city]",
+		"uniques": [
+			"[20]% Food is carried over after population increases [in this city]",
 			"[+1 Food] <with [Salt]>",
 			"[-1 Production, +1 Gold] <with [Alcohol]>",
 			"[-1 Production, +1 Gold] <with [Narcotics]>",
-			"[-1 Production, -1 Food, +1 Gold] <with [Refined Narcotics]>"]
-	},	
+			"[-1 Production, -1 Food, +1 Gold] <with [Refined Narcotics]>"
+		]
+	},
 	{
-		"name": "Deep Larder", 
+		"name": "Deep Larder",
 		"replaces": "Food Store",
 		"uniqueTo": "Enclavers",
 		"cost": 10,
 		"hurryCostModifier": -25,
-		"uniques": ["[30]% Food is carried over after population increases [in this city]",
+		"uniques": [
+			"[30]% Food is carried over after population increases [in this city]",
 			"[+1 Food] <with [Salt]>",
 			"[-1 Production, +1 Gold] <with [Alcohol]>",
 			"[-1 Production, +1 Gold] <with [Narcotics]>",
-			"[-1 Production, -1 Food, +1 Gold] <with [Refined Narcotics]>"]
-	},	
+			"[-1 Production, -1 Food, +1 Gold] <with [Refined Narcotics]>"
+		]
+	},
 	{
-		"name": "Cold Store", 
-		"percentStatBonus": {"food": 10},
+		"name": "Cold Store",
+		"percentStatBonus": { "food": 10 },
 		"maintenance": 1,
-		"uniques": ["[+1 Food] from [Goats] tiles [in this city]",
+		"uniques": [
+			"[+1 Food] from [Goats] tiles [in this city]",
 			"[+1 Food] from [Cattle] tiles [in this city]",
 			"[+1 Food] from [Deer] tiles [in this city]",
 			"[+1 Food] from [Algae] tiles [in this city]",
 			"[+1 Food] from [Jellyfish] tiles [in this city]",
 			"[+1 Food] from [Plankton] tiles [in this city]",
 			"[+1 Food] from [Hogs] tiles [in this city]",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"hurryCostModifier": 25,
 		"requiredTech": "Refrigeration"
-	},		
-		
+	},
 	{
-		"name": "Ranch", 
-		"requiredNearbyImprovedResources": ["Cattle","Goats","Furs"],
+		"name": "Ranch",
+		"requiredNearbyImprovedResources": ["Cattle", "Goats", "Furs"],
 		"maintenance": 1,
 		"hurryCostModifier": 25,
-		"uniques": ["[+1 Food] from [Cattle] tiles [in this city]",
+		"uniques": [
+			"[+1 Food] from [Cattle] tiles [in this city]",
 			"[+1 Food] from [Insects] tiles [in this city]",
 			"[+1 Food] from [Goats] tiles [in this city]",
-			"[+1 Food] from [Furs] tiles [in this city]"],
+			"[+1 Food] from [Furs] tiles [in this city]"
+		],
 		"requiredTech": "Redomestication"
-	},		
+	},
 	{
-		"name": "Greenhouse", 
+		"name": "Greenhouse",
 		"food": 2,
-		"specialistSlots": {"Farmer": 1},
-		"uniques": ["[+1 Food] from [Tubers] tiles [in this city]",
-			"[+1 Food] from [Wheat] tiles [in this city]"],
+		"specialistSlots": { "Farmer": 1 },
+		"uniques": [
+			"[+1 Food] from [Tubers] tiles [in this city]",
+			"[+1 Food] from [Wheat] tiles [in this city]"
+		],
 		"maintenance": 1,
 		"hurryCostModifier": 25,
 		"requiredTech": "Botany"
-	},			
+	},
 	{
-		"name": "Hydroponic Farming", 
+		"name": "Hydroponic Farming",
 		"food": 2,
-		"specialistSlots": {"Farmer": 3},
+		"specialistSlots": { "Farmer": 3 },
 		"maintenance": 1,
 		"hurryCostModifier": 25,
 		"uniques": ["Consumes [1] [Power]"],
 		"requiredTech": "Hydroponics"
-	},		
+	},
 	{
-		"name": "Mycoprotein Vats", 
+		"name": "Mycoprotein Vats",
 		"food": 6,
 		"maintenance": 3,
 		"hurryCostModifier": 25,
 		"uniques": ["Consumes [1] [Power]"],
 		"requiredTech": "Genetics"
-	},	
+	},
 	{
-		"name": "Reclamation Vats", 
-		"percentStatBonus": {"food": 25},
+		"name": "Reclamation Vats",
+		"percentStatBonus": { "food": 25 },
 		"maintenance": 4,
-		"hurryCostModifier": 25,		
+		"hurryCostModifier": 25,
 		"requiredTech": "Human Genome"
-	},	
-
+	},
 	{
 		"name": "Hospital",
 		"science": -1,
 		"maintenance": 3,
 		"hurryCostModifier": 0,
 		"requiredTech": "Biology",
-		"uniques": ["[30]% Food is carried over after population increases [in this city]",
+		"uniques": [
+			"[30]% Food is carried over after population increases [in this city]",
 			"All newly-trained [relevant] units [in this city] receive the [Medic I] promotion",
 			"[+1 Food] <with [Harvested Organs]>",
-			"Consumes [1] [Power]"]
-	},	
+			"Consumes [1] [Power]"
+		]
+	},
 	{
 		"name": "Organ Farm",
 		"replaces": "Hospital",
@@ -729,11 +903,13 @@
 		"maintenance": 2,
 		"hurryCostModifier": 0,
 		"requiredTech": "Biology",
-		"uniques": ["[10]% Food is carried over after population increases [in this city]",
+		"uniques": [
+			"[10]% Food is carried over after population increases [in this city]",
 			"[+1 Food] <with [Harvested Organs]>",
 			"Provides [1] [Harvested Organs]",
-			"Consumes [1] [Slaves]"]
-	},	
+			"Consumes [1] [Slaves]"
+		]
+	},
 	{
 		"name": "Blood Bank",
 		"replaces": "Hospital",
@@ -741,34 +917,38 @@
 		"maintenance": 2,
 		"hurryCostModifier": 0,
 		"requiredTech": "Biology",
-		"uniques": ["[10]% Food is carried over after population increases [in this city]",
+		"uniques": [
+			"[10]% Food is carried over after population increases [in this city]",
 			"[+1 Food] <with [Harvested Organs]>",
 			"[Armor] units gain the [Resupply] promotion",
-			"Consumes [1] [Slaves]"]
-	},	
-
+			"Consumes [1] [Slaves]"
+		]
+	},
 	{
 		"name": "Medical Lab",
 		"science": -1,
 		"maintenance": 2,
 		"requiredTech": "Pharmaceuticals",
-		"uniques": ["[20]% Food is carried over after population increases [in this city]",
-			"Only available <in cities with a [Hospital]>"]
+		"uniques": [
+			"[20]% Food is carried over after population increases [in this city]",
+			"Only available <in cities with a [Hospital]>"
+		]
 	},
-	//organ cloning lab
+	// Organ cloning lab
 	{
 		"name": "Organ Lab",
 		"isNationalWonder": true,
 		"science": -1,
 		"maintenance": 2,
-		"requiredTech": "Human Genome",//cloning?
-		"uniques": ["Provides [2] [Harvested Organs]",
+		"requiredTech": "Human Genome", // cloning?
+		"uniques": [
+			"Provides [2] [Harvested Organs]",
 			"Only available <in cities with a [Medical Lab]>",
-			"Consumes [1] [Power]"]
+			"Consumes [1] [Power]"
+		]
 	},
-	
-	//	CULTURE, HAPPPINESS
-	
+
+	// Culture and Hapiness buildings
 	{
 		"name": "Monument",
 		"culture": 2,
@@ -780,7 +960,9 @@
 		"replaces": "Monument",
 		"uniqueTo": "The Mariners",
 		"culture": 1,
-		"uniques": ["[+1 Culture, +1 Food] from [Fishing Boats] tiles [in this city]"],
+		"uniques": [
+			"[+1 Culture, +1 Food] from [Fishing Boats] tiles [in this city]"
+		],
 		"cost": 40,
 		"hurryCostModifier": 40
 	},
@@ -796,93 +978,107 @@
 	{
 		"name": "Domestic Electrification",
 		"isNationalWonder": true,
-		"uniques": ["[+2 Happiness, +2 Culture] <with [Power]>",
+		"uniques": [
+			"[+2 Happiness, +2 Culture] <with [Power]>",
 			"[+2 Happiness] <with [Data]>",
 			"[+2 Happiness] <with [Electronics]>",
 			"[+2 Happiness] <with [Machine Parts]>",
 			"Cost increases by [50] per owned city",
 			"Can only be built [in capital]",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"hurryCostModifier": 25,
 		"requiredTech": "Engineering"
-	},	
+	},
 	{
 		"name": "Town Hall",
-		"specialistSlots": {"Administrator": 1},
-		"maintenance": 1,	
-		"uniques": ["[-25]% Culture cost of natural border growth [in this city]",
+		"specialistSlots": { "Administrator": 1 },
+		"maintenance": 1,
+		"uniques": [
+			"[-25]% Culture cost of natural border growth [in this city]",
 			"[-25]% Gold cost of acquiring tiles [in this city]",
-			"[+1 Happiness, +1 Culture] <with [Power]>"],
+			"[+1 Happiness, +1 Culture] <with [Power]>"
+		],
 		"hurryCostModifier": 25,
 		"requiredTech": "Civil Service"
-	},		
+	},
 	{
 		"name": "Commune",
 		"replaces": "Town Hall",
 		"uniqueTo": "Children of Rust",
 		"happiness": 1,
 		"culture": 1,
-		"maintenance": 1,	
+		"maintenance": 1,
 		"cost": 40,
-		"uniques": ["[-25]% Culture cost of natural border growth [in this city]",
-			"[-25]% Gold cost of acquiring tiles [in this city]"
-			,"[+1 Happiness, +1 Culture] <with [Power]>",
-			"[+1] population [in this city]"],
+		"uniques": [
+			"[-25]% Culture cost of natural border growth [in this city]",
+			"[-25]% Gold cost of acquiring tiles [in this city]",
+			"[+1 Happiness, +1 Culture] <with [Power]>",
+			"[+1] population [in this city]"
+		],
 		"hurryCostModifier": 40
 	},
 	{
 		"name": "Personnel Office",
 		"replaces": "Town Hall",
 		"uniqueTo": "Blackwarden",
-		//"specialistSlots": {"Merchant": 1},
-		"maintenance": 1,	
-		"uniques": ["[+33]% Production when constructing [Worker] units [in this city]",
+		// "specialistSlots": { "Merchant": 1 },
+		"maintenance": 1,
+		"uniques": [
+			"[+33]% Production when constructing [Worker] units [in this city]",
 			"[+1 Happiness, +1 Culture] <with [Power]>",
-			"[+1 Food, +3 Production] <with [Slaves]>"],
-		"cost": 40,		
+			"[+1 Food, +3 Production] <with [Slaves]>"
+		],
+		"cost": 40,
 		"hurryCostModifier": -25
-	},		
+	},
 	{
-		"name": "Casino", 
+		"name": "Casino",
 		"replaces": "Town Hall",
 		"uniqueTo": "Deadrock Clan",
-		"specialistSlots": {"Merchant": 1},
+		"specialistSlots": { "Merchant": 1 },
 		"happiness": 1,
-		"uniques": ["[+1 Gold] per [3] population [in this city]",
+		"uniques": [
+			"[+1 Gold] per [3] population [in this city]",
 			"[+1 Happiness, +1 Culture, +1 Gold] <with [Power]>",
 			"[+1 Gold] <with [Slaves]>",
 			"[+1 Gold] <with [Alcohol]>",
 			"[+1 Gold] <with [Narcotics]>",
-			"[+1 Gold] <with [Refined Narcotics]>"],
+			"[+1 Gold] <with [Refined Narcotics]>"
+		],
 		"requiredTech": "Currency"
-	},	
+	},
 	{
-		"name": "Slave Market", 
+		"name": "Slave Market",
 		"replaces": "Town Hall",
 		"uniqueTo": "Crimson Legion",
-		"percentStatBonus": {"food": 10},
-		"specialistSlots": {"Merchant": 1},
+		"percentStatBonus": { "food": 10 },
+		"specialistSlots": { "Merchant": 1 },
 		"culture": 1,
 		"happiness": 1,
-		"uniques": ["[+50]% Production when constructing [Worker] units [in this city]",
+		"uniques": [
+			"[+50]% Production when constructing [Worker] units [in this city]",
 			"[+1 Gold, +1 Production] <with [Slaves]>",
 			"Only available <with [Slaves]>",
-			"Consumes [1] [Slaves]"],
+			"Consumes [1] [Slaves]"
+		],
 		"requiredTech": "Trade"
-	},	
+	},
 	{
-		"name": "Plantation", 
+		"name": "Plantation",
 		"replaces": "Town Hall",
 		"uniqueTo": "Cult of Ignis",
-		"percentStatBonus": {"food": 20},
-		"uniques": ["[+75]% Production when constructing [Worker] units [in this city]",
+		"percentStatBonus": { "food": 20 },
+		"uniques": [
+			"[+75]% Production when constructing [Worker] units [in this city]",
 			"[+2 Food] <with [Slaves]>",
 			"Only available <with [Slaves]>",
-			"Consumes [1] [Slaves]"],
-		"cost": 40,		
+			"Consumes [1] [Slaves]"
+		],
+		"cost": 40,
 		"hurryCostModifier": 25
-	},	
-	{	
+	},
+	{
 		"name": "Museum",
 		"culture": 1,
 		"science": 1,
@@ -894,28 +1090,32 @@
 		"name": "Broadcast Tower",
 		"culture": 1,
 		"happiness": 1,
-		"specialistSlots": {"Administrator": 1},
-		"percentStatBonus": {"culture": 25},
+		"specialistSlots": { "Administrator": 1 },
+		"percentStatBonus": { "culture": 25 },
 		"uniques": ["Consumes [1] [Power]"],
-	//	"maintenance": 3,
+		// "maintenance": 3,
 		"requiredTech": "Radio"
-	},	
+	},
 	{
 		"name": "Television Studio",
 		"culture": 1,
 		"happiness": 2,
-		"specialistSlots": {"Administrator": 1},
+		"specialistSlots": { "Administrator": 1 },
 		"maintenance": 1,
-		"uniques": ["Only available <in cities with a [Broadcast Tower]>",
-			"Consumes [1] [Power]"],
+		"uniques": [
+			"Only available <in cities with a [Broadcast Tower]>",
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Electronics"
-	},	
+	},
 	{
 		"name": "Broadcast Network",
 		"happiness": 2,
 		"culture": 2,
-		"uniques": ["Provides 1 happiness per 2 additional social policies adopted",
-			"Only available <in cities with a [Television Studio]>"],
+		"uniques": [
+			"Provides 1 happiness per 2 additional social policies adopted",
+			"Only available <in cities with a [Television Studio]>"
+		],
 		"isNationalWonder": true,
 		"requiredTech": "Social Engineering"
 	},
@@ -925,53 +1125,53 @@
 		"maintenance": 1,
 		"requiredTech": "Social Engineering"
 	},
-	{	
-
+	{
 		"name": "Distillery",
-	//	"culture": 1,
+		// "culture": 1,
 		"happiness": 2,
-		"maintenance": 1,		
+		"maintenance": 1,
 		"uniques": ["Provides [1] [Alcohol]"],
-		"requiredNearbyImprovedResources": ["Wheat","Tubers"],
+		"requiredNearbyImprovedResources": ["Wheat", "Tubers"],
 		"hurryCostModifier": 25,
 		"requiredTech": "Chemistry"
 	},
 
-
-    
-	//	ECONOMY
-	
+	// Water buildings
 	{
-		"name": "Market", 
-		"specialistSlots": {"Merchant": 2},
+		"name": "Market",
+		"specialistSlots": { "Merchant": 2 },
 		"hurryCostModifier": 25,
 		"requiredTech": "Trade",
 		"uniques": ["[+1 Gold] from [Luxury resource] tiles [in this city]"]
 	},
 	{
-		"name": "Caravan Office", 
+		"name": "Caravan Office",
 		"replaces": "Market",
 		"uniqueTo": "Commonwealth",
 		"gold": 2,
-		"specialistSlots": {"Merchant": 2},
+		"specialistSlots": { "Merchant": 2 },
 		"hurryCostModifier": 25,
-		"greatPersonPoints": {"Great Merchant": 1},
-		"uniques": ["5% Production for every Trade Route with a City-State in the empire",
-			"[+1 Gold] from [Luxury resource] tiles [in this city]"],
+		"greatPersonPoints": { "Great Merchant": 1 },
+		"uniques": [
+			"5% Production for every Trade Route with a City-State in the empire",
+			"[+1 Gold] from [Luxury resource] tiles [in this city]"
+		],
 		"requiredTech": "Trade"
 	},
 	{
 		"name": "Water Plant",
-		"percentStatBonus": {"gold": 20},
+		"percentStatBonus": { "gold": 20 },
 		"maintenance": 0,
-		"uniques": ["[+1 Gold] from [Groundwater] tiles [in this city]",
-			"Consumes [1] [Power]"],
+		"uniques": [
+			"[+1 Gold] from [Groundwater] tiles [in this city]",
+			"Consumes [1] [Power]"
+		],
 		"hurryCostModifier": 25,
 		"requiredTech": "Decontamination"
 	},
 	{
 		"name": "Water Storage",
-		"percentStatBonus": {"gold": 10},
+		"percentStatBonus": { "gold": 10 },
 		"requiredTech": "Currency",
 		"uniques": ["Doubles Gold given to enemy if city is captured"]
 	},
@@ -980,91 +1180,95 @@
 		"gold": 3,
 		"food": 1,
 		"production": -2,
-		"percentStatBonus": {"production": -5, "gold": 10},
-		"specialistSlots": {"Merchant": 1},
-		"uniques": ["Provides [1] [Groundwater]",
+		"percentStatBonus": { "production": -5, "gold": 10 },
+		"specialistSlots": { "Merchant": 1 },
+		"uniques": [
+			"Provides [1] [Groundwater]",
 			"[+1 Gold] <with [Power]>",
 			"[+1 Gold, -1 Production] from [River] tiles [in this city]",
 			"Consumes [1] [Power]",
-			"Only available <in cities with a [Factory]>"],
+			"Only available <in cities with a [Factory]>"
+		],
 		"requiredTech": "Desalination"
 	},
 	{
 		"name": "Rainwater Purifier",
 		"gold": 2,
-		"specialistSlots": {"Merchant": 1},
+		"specialistSlots": { "Merchant": 1 },
 		"requiredTech": "Atmosphere Remediation",
 		"uniques": ["[+1 Gold] from [Moisture trap] tiles [in this city]"]
 	},
 
-
-
-	
-		
-	//SCI
+	// Science buildings
 	{
-		"name": "Library",		
+		"name": "Library",
 		"hurryCostModifier": 25,
-		"uniques": ["[+1 Science] <with [Power]>",
+		"uniques": [
+			"[+1 Science] <with [Power]>",
 			"[+1 Science] per [2] population [in this city]",
-			"[+1 Science, +1 Culture] from [Books] tiles [in this city]"],
+			"[+1 Science, +1 Culture] from [Books] tiles [in this city]"
+		],
 		"requiredTech": "Writing"
-	},	
+	},
 	{
-		"name": "Information Market",	
+		"name": "Information Market",
 		"replaces": "Library",
-		"uniqueTo": "Deadrock Clan",	
+		"uniqueTo": "Deadrock Clan",
 		"gold": 1,
 		"science": 1,
-		"greatPersonPoints": {"Great Scientist": 1},
+		"greatPersonPoints": { "Great Scientist": 1 },
 		"uniques": ["[+1 Science] <with [Power]>"],
 		"requiredTech": "Writing"
-	},	
+	},
 	{
-		"name": "Study",		
+		"name": "Study",
 		"replaces": "Library",
 		"uniqueTo": "Crimson Legion",
 		"science": 1,
-		"greatPersonPoints": {"Great Scientist": 1},
+		"greatPersonPoints": { "Great Scientist": 1 },
 		"uniques": ["[+1 Science] <with [Power]>"],
 		"hurryCostModifier": 25,
 		"requiredTech": "Writing"
-	},	
+	},
 	{
-		"name": "Sanctum",		
+		"name": "Sanctum",
 		"replaces": "Library",
 		"uniqueTo": "Cult of Ignis",
 		"culture": 1,
 		"science": 2,
-		"greatPersonPoints": {"Great Scientist": 1},
-		"requiredNearbyImprovedResources": ["Books","Data","Encrypted Data"],
+		"greatPersonPoints": { "Great Scientist": 1 },
+		"requiredNearbyImprovedResources": ["Books", "Data", "Encrypted Data"],
 		"uniques": ["[+1 Science] <with [Power]>"],
 		"hurryCostModifier": 25,
 		"requiredTech": "Writing"
-	},	
+	},
 	{
 		"name": "National College",
 		"science": 2,
 		"culture": 1,
 		"isNationalWonder": true,
-		"percentStatBonus": {"science": 33},
-		"uniques": ["Requires a [Library] in all cities",
-			"Cost increases by [30] per owned city"],
+		"percentStatBonus": { "science": 33 },
+		"uniques": [
+			"Requires a [Library] in all cities",
+			"Cost increases by [30] per owned city"
+		],
 		"requiredTech": "Education"
-	},	
+	},
 	{
 		"name": "University",
 		"maintenance": 1,
 		"hurryCostModifier": 15,
-		"percentStatBonus": {"science": 33},
-		"specialistSlots": {"Scientist": 1},
-		"uniques": ["[+1 Science] from [Jungle] tiles [in this city]",
+		"percentStatBonus": { "science": 33 },
+		"specialistSlots": { "Scientist": 1 },
+		"uniques": [
+			"[+1 Science] from [Jungle] tiles [in this city]",
 			"[+1 Science] from [Forest] tiles [in this city]",
 			"[+1 Science] from [Sunken Ruins] tiles [in this city]",
 			"[+1 Science] <with [Power]>",
-			"Only available <in cities with a [Library]>"],
+			"Only available <in cities with a [Library]>"
+		],
 		"requiredTech": "Education"
-	},	
+	},
 	{
 		"name": "Trade College",
 		"replaces": "University",
@@ -1072,13 +1276,17 @@
 		"culture": 1,
 		"maintenance": 1,
 		"hurryCostModifier": 33,
-		"greatPersonPoints": {"Great Administrator": 1 /*, "Great General": 1*/},
-		"specialistSlots": {"Scientist": 1,"Merchant":1},
-		"uniques": ["[+1 Science] from [Jungle] tiles [in this city]",
+		"greatPersonPoints": {
+			"Great Administrator": 1 /*, "Great General": 1*/
+		},
+		"specialistSlots": { "Scientist": 1, "Merchant": 1 },
+		"uniques": [
+			"[+1 Science] from [Jungle] tiles [in this city]",
 			"[+1 Science] from [Forest] tiles [in this city]",
 			"[+1 Science] from [Sunken Ruins] tiles [in this city]",
 			"[+1 Science] <with [Power]>",
-			"Only available <in cities with a [Library]>"],
+			"Only available <in cities with a [Library]>"
+		],
 		"requiredTech": "Education"
 	},
 	{
@@ -1088,15 +1296,17 @@
 		"culture": 1,
 		"maintenance": 1,
 		"hurryCostModifier": 15,
-		"greatPersonPoints": {"Great Scientist": 1, "Great Administrator": 1},
-		"specialistSlots": {"Administrator": 1},
-		"uniques": ["[+1 Science] from [Jungle] tiles [in this city]",
+		"greatPersonPoints": { "Great Scientist": 1, "Great Administrator": 1 },
+		"specialistSlots": { "Administrator": 1 },
+		"uniques": [
+			"[+1 Science] from [Jungle] tiles [in this city]",
 			"[+1 Science] from [Forest] tiles [in this city]",
 			"[+1 Science] from [Sunken Ruins] tiles [in this city]",
 			"Only available <in cities with a [Library]>",
-			"[+1 Culture] <with [Power]>"],
+			"[+1 Culture] <with [Power]>"
+		],
 		"requiredTech": "Education"
-	},	
+	},
 	{
 		"name": "College of Mystics",
 		"replaces": "University",
@@ -1104,45 +1314,56 @@
 		"culture": 1,
 		"maintenance": 1,
 		"hurryCostModifier": 15,
-		"greatPersonPoints": {"Great Scientist": 1},
-		"specialistSlots": {"Scientist": 1},
-		"uniques": ["[+1 Science] from [Jungle] tiles [in this city]",
+		"greatPersonPoints": { "Great Scientist": 1 },
+		"specialistSlots": { "Scientist": 1 },
+		"uniques": [
+			"[+1 Science] from [Jungle] tiles [in this city]",
 			"[+1 Science] from [Forest] tiles [in this city]",
 			"[+1 Science] from [Sunken Ruins] tiles [in this city]",
 			"[+1 Science] <with [Power]>",
 			"Only available <in cities with a [Library]>",
-			"[+1 Culture, +1 Science] <with [Power]>"],
+			"[+1 Culture, +1 Science] <with [Power]>"
+		],
 		"requiredTech": "Education"
-	},	
+	},
 	{
 		"name": "Public School",
 		"maintenance": 1,
 		"hurryCostModifier": 0,
-		//"cannotBeBuiltWith": "Private School",
-		"uniques": ["[+1 Science, +1 Culture] per [3] population [in this city]",
+		// "cannotBeBuiltWith": "Private School",
+		"uniques": [
+			"[+1 Science, +1 Culture] per [3] population [in this city]",
 			"Only available <in cities with a [Library]>",
-			"[+1 Culture] <with [Power]>"],
+			"[+1 Culture] <with [Power]>"
+		],
 		"requiredTech": "Civil Service"
 	},
-	/*{
+	/*
+	{
 		"name": "Private School",
 		"maintenance": 1,
 		"hurryCostModifier": -50,
-		"requiredBuilding": "Library",
 		"cannotBeBuiltWith": "Public School",
-		"uniques": ["[+1 Science, +1 Gold] per [3] population [in this city]","Requires [Privatization]","Only available <in cities with a [Library]>"],
+		"uniques": [
+			"[+1 Science, +1 Gold] per [3] population [in this city]",
+			"Requires [Privatization]",
+			"Only available <in cities with a [Library]>"
+		],
 		"requiredTech": "Currency"
-	},*/
+	},
+	*/
 	{
 		"name": "Clubhouse",
 		"replaces": "Public School",
 		"uniqueTo": "Deadrock Clan",
 		"food": -1,
-		//"greatPersonPoints": {"Great General": 1},
-		"uniques": ["Can recruit Clansman infantry",
+		// "greatPersonPoints": { "Great General": 1 },
+		"uniques": [
+			"Can recruit Clansman infantry",
 			"[+1 Culture] per [3] population [in this city]",
 			"[+1 Gold] <with [Slaves]>",
-			"[+20]% Production when constructing [Military] units [in this city]"],
+			"[+20]% Production when constructing [Military] units [in this city]"
+		],
 		"maintenance": 1,
 		"hurryCostModifier": 25,
 		"requiredTech": "Secrets of the Past"
@@ -1152,10 +1373,12 @@
 		"replaces": "Public School",
 		"uniqueTo": "Crimson Legion",
 		"food": -1,
-		"uniques": ["[+15]% Production when constructing [Military] units [in this city]",
+		"uniques": [
+			"[+15]% Production when constructing [Military] units [in this city]",
 			"New [Military] units start with [15] Experience [in this city]",
-			"Only available <in cities with a [Barracks]>"],
-		// "greatPersonPoints": {"Great General": 1},
+			"Only available <in cities with a [Barracks]>"
+		],
+		// "greatPersonPoints": { "Great General": 1 },
 		"maintenance": 1,
 		"hurryCostModifier": 25,
 		"requiredTech": "Civil Service"
@@ -1168,130 +1391,104 @@
 		"culture": 1,
 		"maintenance": 1,
 		"hurryCostModifier": 0,
-		"uniques": ["New [Military] units start with [15] Experience [in this city]",
+		"uniques": [
+			"New [Military] units start with [15] Experience [in this city]",
 			"[+1 Science] from [Jungle] tiles [in this city]",
 			"[+1 Science] from [Forest] tiles [in this city]",
 			"[+1 Science] from [Sunken Ruins] tiles [in this city]",
-			"Only available <in cities with a [Sanctum]>"],
+			"Only available <in cities with a [Sanctum]>"
+		],
 		"requiredTech": "Civil Service"
 	},
-	
 	{
 		"name": "Research Lab",
-		"percentStatBonus": {"science": 50},
-		"specialistSlots": {"Scientist": 2},
+		"percentStatBonus": { "science": 50 },
+		"specialistSlots": { "Scientist": 2 },
 		"maintenance": 1,
-		"uniques": ["Only available <in cities with a [University]>",
-			"Consumes [1] [Power]"],
+		"uniques": [
+			"Only available <in cities with a [University]>",
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Laboratory"
-	},		
-
+	},
 	{
 		"name": "Data Center",
 		"maintenance": 2,
 		"hurryCostModifier": 25,
-		"percentStatBonus": {"science": 50},
-		"specialistSlots": {"Scientist": 1},
+		"percentStatBonus": { "science": 50 },
+		"specialistSlots": { "Scientist": 1 },
 		"requiredTech": "Networking",
-		"uniques": ["[+1 Science, +1 Culture] from [Data] tiles [in this city]",
+		"uniques": [
+			"[+1 Science, +1 Culture] from [Data] tiles [in this city]",
 			"[+1 Science, +1 Culture] from [Encrypted Data] tiles [in this city]",
-			"Consumes [1] [Power]"]
+			"Consumes [1] [Power]"
+		]
 	},
-	/*{
+	/*
+	{
 		"name": "Content Mill",
 		"replaces": "Data Center",
 		"uniqueTo": "Deadrock Clan",
 		"maintenance": 2,
 		"hurryCostModifier": 25,
-		"percentStatBonus": {"science": 50},
-		"specialistSlots": {"Scientist": 1},
-		"requiredResource": "Power",	//power
+		"percentStatBonus": { "science": 50 },
+		"specialistSlots": { "Scientist": 1 },
+		"requiredResource": "Power",
 		"uniques": ["Provides [1] [Data]"],
 		"requiredTech": "Networking"
-		"resourceBonusStats": {"science": 1,"culture": 1},
-	},*/
+		"resourceBonusStats": { "science": 1, "culture": 1 },
+	},
+	*/
 	{
-		"name": "Media Center",	//op
+		"name": "Media Center", // op
 		"happiness": 3,
 		"culture": 2,
 		"isNationalWonder": true,
 		"requiredNearbyImprovedResources": ["Data"],
-		"greatPersonPoints": {"Great Administrator": 2},
+		"greatPersonPoints": { "Great Administrator": 2 },
 		"uniques": ["Consumes [1] [Power]"],
 		"requiredTech": "Networking"
-	},	
+	},
 	{
 		"name": "Decryption Center",
 		"culture": 1,
-		"greatPersonPoints": {"Great Scientist": 1},
-		"uniques": ["Consumes [1] [Encrypted Data]",
+		"greatPersonPoints": { "Great Scientist": 1 },
+		"uniques": [
+			"Consumes [1] [Encrypted Data]",
 			"[+2 Science] <with [Power]>",
-			"Only available <in cities with a [Data Center]>"],
-		"percentStatBonus": {"science": 25},
+			"Only available <in cities with a [Data Center]>"
+		],
+		"percentStatBonus": { "science": 25 },
 		"requiredTech": "Decryption"
-	},			
-	{
-		"name": "Skunkworks",
-		"culture": 1,
-		"greatPersonPoints": {"Great Scientist": 2},
-		"isWonder": true,
-		"uniques": ["Consumes [1] [Encrypted Data]",
-			"[+3 Science] <with [Power]>",
-			"Only available <in cities with a [Data Center]>",
-			"Free Technology"],
-		"requiredTech": "Decryption",
-		"quote": "Many times a customer would come to the Skunk Works with a request and on a handshake the project would begin, no contracts in place, no official submittal process."
-	},	
-	{
-		"name": "Supercollider",
-		"science": 5,
-		"culture": 1,
-		"greatPersonPoints": {"Great Scientist": 2},
-		"isWonder": true,
-		"uniques": ["[2] free [Great Scientist] units appear",
-			"Consumes [1] [Power]"],
-		"percentStatBonus": {"science": 50},
-		"requiredTech": "Particle Physics",
-		"quote": "God does not play dice."
 	},
 	{
 		"name": "Communications Satellite",
 		"happiness": 2,
-		"science": 2,		
+		"science": 2,
 		"culture": 5,
-		"greatPersonPoints": {"Great Engineer": 1},
+		"greatPersonPoints": { "Great Engineer": 1 },
 		"isNationalWonder": true,
-		"uniques": ["Science gained from research agreements [+50]%",
-			"Only available <in cities with a [Aerospace Facility]>"],
+		"uniques": [
+			"Science gained from research agreements [+50]%",
+			"Only available <in cities with a [Aerospace Facility]>"
+		],
 		"requiredTech": "Satellites"
 	},
 	{
 		"name": "Surveillance Satellite",
-		"happiness": 5,	
+		"happiness": 5,
 		"culture": 2,
-		"greatPersonPoints": {"Great Engineer": 1},
-		"isNationalWonder": true,		
-		"uniques": ["[+1] Sight <for [All] units>",
-			"Reveals the entire map",
-			"Only available <in cities with a [Aerospace Facility]>"],
-		"requiredTech": "Incentivization"
-	},
-	//wonders	
-	{
-		"name": "Satnav Network",
-		"science": 1,	
-		"greatPersonPoints": {"Great Engineer": 2},
-		"isWonder": true,
-		"uniques": ["Gold from all trade routes +25%",
-			"[+1] Movement <for [All] units>",
+		"greatPersonPoints": { "Great Engineer": 1 },
+		"isNationalWonder": true,
+		"uniques": [
 			"[+1] Sight <for [All] units>",
 			"Reveals the entire map",
-			"Only available <in cities with a [Aerospace Facility]>"],
-		"requiredTech": "Satellites",
-		"quote": "I must down to the seas again, to the lonely sea and the sky,\nAnd all I ask is a tall ship and a star to steer her by"
+			"Only available <in cities with a [Aerospace Facility]>"
+		],
+		"requiredTech": "Incentivization"
 	},
-	
-	//military
+
+	// Military buildings
 	{
 		"name": "Walls",
 		"cityStrength": 1,
@@ -1299,301 +1496,348 @@
 		"hurryCostModifier": 25,
 		"requiredTech": "Construction",
 		"uniques": ["Destroyed when the city is captured"]
-	},		
+	},
 	{
 		"name": "Defensive Emplacements",
 		"cityStrength": 5,
 		"cityHealth": 20,
 		"hurryCostModifier": 0,
-		"uniques": ["Only available <in cities with a [Walls]>",
-			"Destroyed when the city is captured"],
+		"uniques": [
+			"Only available <in cities with a [Walls]>",
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Machinery"
-	},	
+	},
 	{
 		"name": "Choke Points",
 		"cityStrength": 2,
 		"cityHealth": 80,
 		"hurryCostModifier": 25,
-		"uniques": ["Must be on [Hill]",
+		"uniques": [
+			"Must be on [Hill]",
 			"Only available <in cities with a [Walls]>",
-			"Destroyed when the city is captured"],
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Mining"
-	},		
+	},
 	{
 		"name": "Hardened Defenses",
 		"cityHealth": 120,
 		"hurryCostModifier": 25,
-		"uniques": ["Only available <in cities with a [Walls]>",
-			"Destroyed when the city is captured"],
+		"uniques": [
+			"Only available <in cities with a [Walls]>",
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Steel"
-	},	
+	},
 	{
 		"name": "Battery",
 		"cityStrength": 10,
 		"maintenance": 1,
 		"hurryCostModifier": 0,
-		"uniques": ["Only available <in cities with a [Walls]>",
-			"Destroyed when the city is captured"],
+		"uniques": [
+			"Only available <in cities with a [Walls]>",
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Munitions"
-	},		
+	},
 	{
 		"name": "Bunker",
 		"cityHealth": 200,
 		"maintenance": 1,
 		"hurryCostModifier": 50,
 		"requiredTech": "Munitions",
-		"uniques": ["Population loss from nuclear attacks [-75]% [in this city]",
-			"Destroyed when the city is captured"]
-	},		
-	{ 
-		"name": "Active Denial System", 
+		"uniques": [
+			"Population loss from nuclear attacks [-75]% [in this city]",
+			"Destroyed when the city is captured"
+		]
+	},
+	{
+		"name": "Active Denial System",
 		"happiness": 3,
 		"maintenance": 1,
 		"cityHealth": 50,
 		"hurryCostModifier": 25,
-		"uniques": ["Consumes [1] [Power]",
-			"Destroyed when the city is captured"],
+		"uniques": [
+			"Consumes [1] [Power]",
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Energy Weapons"
-	},	
+	},
 	{
 		"name": "Listening Post",
 		"maintenance": 1,
 		"happiness": 1,
 		"hurryCostModifier": 25,
-		"uniques": ["Remove extra unhappiness from annexed cities",
+		"uniques": [
+			"Remove extra unhappiness from annexed cities",
 			"Only available <in cities without a [Prison Camp]>",
-			"Destroyed when the city is captured"],
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Civil Service"
 	},
-    {	
+	{
 		"name": "Arena",
 		"replaces": "Listening Post",
 		"uniqueTo": "Cult of Ignis",
 		"happiness": 1,
 		"maintenance": 1,
 		"hurryCostModifier": 25,
-		"uniques": ["New [Military] units start with [15] Experience [in this city]",
+		"uniques": [
+			"New [Military] units start with [15] Experience [in this city]",
 			"Remove extra unhappiness from annexed cities",
 			"[+1 Happiness, +1 Culture] <with [Slaves]>",
 			"Only available <in cities without a [Prison Camp]>",
-			"Destroyed when the city is captured"],
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Machinery"
 	},
-	{ 
+	{
 		"name": "Colosseum",
 		"replaces": "Listening Post",
 		"uniqueTo": "Crimson Legion",
 		"happiness": 1,
 		"maintenance": 1,
 		"hurryCostModifier": 25,
-		"uniques": ["New [Military] units start with [15] Experience [in this city]",
+		"uniques": [
+			"New [Military] units start with [15] Experience [in this city]",
 			"Remove extra unhappiness from annexed cities",
 			"[+1 Happiness, +1 Culture] <with [Slaves]>",
 			"Only available <in cities without a [Prison Camp]>",
-			"Destroyed when the city is captured"],
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Engineering"
-	},	
+	},
 	{
-		"name": "Prison Camp", 
-		"hurryCostModifier": -25,	
+		"name": "Prison Camp",
+		"hurryCostModifier": -25,
 		"food": -1,
-		"cost": 20,		
-		"uniques": ["Remove extra unhappiness from annexed cities",
+		"cost": 20,
+		"uniques": [
+			"Remove extra unhappiness from annexed cities",
 			"Can only be built [in annexed cities]",
 			"Provides [1] [Slaves]",
 			"Only available <in cities without a [Listening Post]>",
-			"Destroyed when the city is captured"],
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Construction"
 	},
 	{
-		"name": "Black Site", 
+		"name": "Black Site",
 		"replaces": "Prison Camp",
 		"uniqueTo": "Commonwealth",
 		"food": -1,
 		"maintenance": 1,
-		"cost": 50,		
-		"uniques": ["Remove extra unhappiness from annexed cities",
+		"cost": 50,
+		"uniques": [
+			"Remove extra unhappiness from annexed cities",
 			"Can only be built [in annexed cities]",
 			"Only available <in cities without a [Listening Post]>",
-			"Destroyed when the city is captured"],
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Construction",
-		"hurryCostModifier": -50	
+		"hurryCostModifier": -50
 	},
 	{
-		"name": "Processing Center", 
+		"name": "Processing Center",
 		"replaces": "Prison Camp",
 		"uniqueTo": "Cult of Ignis",
-		"percentStatBonus": {"food": -25},
-		"cost": 15,		
-		"uniques": ["Remove extra unhappiness from annexed cities",
+		"percentStatBonus": { "food": -25 },
+		"cost": 15,
+		"uniques": [
+			"Remove extra unhappiness from annexed cities",
 			"Can only be built [in annexed cities]",
 			"Provides [4] [Slaves]",
 			"Only available <in cities without a [Arena]>",
-			"Destroyed when the city is captured"],
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Construction"
 	},
 	{
-		"name": "Legion Camp", 
+		"name": "Legion Camp",
 		"replaces": "Prison Camp",
 		"uniqueTo": "Crimson Legion",
-		"percentStatBonus": {"food": -25},
-		"cost": 15,		
+		"percentStatBonus": { "food": -25 },
+		"cost": 15,
 		"cityStrength": 10,
 		"cityHealth": 50,
-		"uniques": ["[+15]% Production when constructing [Melee] units [in this city]",
+		"uniques": [
+			"[+15]% Production when constructing [Melee] units [in this city]",
 			"Remove extra unhappiness from annexed cities",
 			"Can only be built [in annexed cities]",
 			"Provides [3] [Slaves]",
 			"Free [Auxiliary] appears",
 			"Only available <in cities without a [Colosseum]>",
-			"Destroyed when the city is captured"],
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Construction"
-	},	
+	},
 	{
 		"name": "Narcotics Refinery",
 		"requiredTech": "Chemistry",
-		"uniques": ["Must have an owned [Narcotics farm] within [3] tiles",
+		"uniques": [
+			"Must have an owned [Narcotics farm] within [3] tiles",
 			"Provides [1] [Refined Narcotics]",
 			"Only available <with [Narcotics]>",
-			"Consumes [1] [Power]"]
+			"Consumes [1] [Power]"
+		]
 	},
 	{
 		"name": "Barracks",
 		"hurryCostModifier": 25,
-		"cost": 50,		
+		"cost": 50,
 		"maintenance": 1,
-		"uniques": ["New [Military] units start with [15] Experience [in this city]",
-			"Destroyed when the city is captured"]
-	},	
+		"uniques": [
+			"New [Military] units start with [15] Experience [in this city]",
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Armory",
 		"cityStrength": 5,
 		"hurryCostModifier": 25,
 		"requiredTech": "Construction",
 		"requiredNearbyImprovedResources": ["Weapons"],
-		"uniques": ["New [Military] units start with [15] Experience [in this city]",
+		"uniques": [
+			"New [Military] units start with [15] Experience [in this city]",
 			"[+1 Production] from [Weapons] tiles [in this city]",
-			"Destroyed when the city is captured"]
-	},		
-
+			"Destroyed when the city is captured"
+		]
+	},
 	{
 		"name": "Military Academy",
-		// "greatPersonPoints": {"Great General": 1},
+		// "greatPersonPoints": { "Great General": 1 },
 		"isNationalWonder": true,
 		"hurryCostModifier": 25,
-		"uniques": ["New [Military] units start with [30] Experience [in this city]",
+		"uniques": [
+			"New [Military] units start with [30] Experience [in this city]",
 			"Only available <in cities with a [Barracks]>",
-			"Free [Great General] appears"],
+			"Free [Great General] appears"
+		],
 		"requiredTech": "Combined Arms"
-	},		
+	},
 	{
 		"name": "Guerilla Camp",
 		"replaces": "Military Academy",
 		"uniqueTo": "Enclavers",
 		"cityStrength": 10,
-		"uniques": ["New [Military] units start with [15] Experience [in this city]",
+		"uniques": [
+			"New [Military] units start with [15] Experience [in this city]",
 			"All newly-trained [relevant] units [in this city] receive the [Guerilla Warfare II] promotion",
-			"Destroyed when the city is captured"],
+			"Destroyed when the city is captured"
+		],
 		"requiredTech": "Combined Arms"
 	},
 
-
-	
-	//INDUSTRY - factory, furnace, provide +prod units. power +%
-	
+	// Industry buldings
+	// factory, furnace, provide +prod units. power +%
 	{
-		"name": "Stable", 
+		"name": "Stable",
 		"requiredNearbyImprovedResources": ["Horses"],
 		"cost": 50,
 		"hurryCostModifier": -25,
-		"uniques": ["Allows production of Mounted troops",
-			"[+2 Production, -1 Food] from [Horses] tiles [in this city]"],
+		"uniques": [
+			"Allows production of Mounted troops",
+			"[+2 Production, -1 Food] from [Horses] tiles [in this city]"
+		],
 		"requiredTech": "Redomestication"
 	},
-
-
 	{
 		"name": "Forge",
 		"production": 1,
 		"hurryCostModifier": 25,
-		"requiredNearbyImprovedResources": ["Scrap","Metal"],
+		"requiredNearbyImprovedResources": ["Scrap", "Metal"],
 		"requiredTech": "Iron Working",
-		"uniques": ["[+15]% Production when constructing [Land] units [in this city]",
+		"uniques": [
+			"[+15]% Production when constructing [Land] units [in this city]",
 			"[+1 Production] <with [Power]>",
-			"[+1 Production] <with [Machine Parts]>"]
+			"[+1 Production] <with [Machine Parts]>"
+		]
 	},
 	{
-		"name": "Salvage Yard", 
+		"name": "Salvage Yard",
 		"replaces": "Forge",
 		"uniqueTo": "Children of Rust",
 		"hurryCostModifier": 25,
 		"requiredTech": "Iron Working",
-		"uniques": ["[+1 Production] from [Scrap] tiles [in this city]",
+		"uniques": [
+			"[+1 Production] from [Scrap] tiles [in this city]",
 			"[+1 Production] from [Forest] tiles [in this city]",
 			"[+1 Production] from [Jungle] tiles [in this city]",
 			"[+1 Production] from [Sunken Ruins] tiles [in this city]",
-			"[+1 Production] <with [Machine Parts]>"]
+			"[+1 Production] <with [Machine Parts]>"
+		]
 	},
 	{
-		"name": "Salvage Exchange", 
+		"name": "Salvage Exchange",
 		"replaces": "Forge",
 		"uniqueTo": "Deadrock Clan",
 		"hurryCostModifier": 25,
 		"maintenance": 1,
 		"requiredTech": "Iron Working",
-		"uniques": ["[+1 Production] from [Scrap] tiles [in this city]",
+		"uniques": [
+			"[+1 Production] from [Scrap] tiles [in this city]",
 			"[+1 Production] from [Forest] tiles [in this city]",
 			"[+1 Production] from [Jungle] tiles [in this city]",
 			"[+1 Production] from [Sunken Ruins] tiles [in this city]",
-			"[+1 Production] <with [Machine Parts]>"]
+			"[+1 Production] <with [Machine Parts]>"
+		]
 	},
 	{
-		"name": "Chop Shop", 
+		"name": "Chop Shop",
 		"replaces": "Forge",
 		"uniqueTo": "Cult of Ignis",
 		"production": 1,
 		"hurryCostModifier": 25,
 		"requiredNearbyImprovedResources": ["Scrap"],
 		"requiredTech": "Iron Working",
-		"uniques": ["[+3 Production] from [Scrap] tiles [in this city]",
+		"uniques": [
+			"[+3 Production] from [Scrap] tiles [in this city]",
 			"[+25]% Production when constructing [Armor] units [in this city]",
-			"[+1 Production] <with [Machine Parts]>"]
+			"[+1 Production] <with [Machine Parts]>"
+		]
 	},
 	{
-		"name": "Blast Furnace", 
+		"name": "Blast Furnace",
 		"maintenance": 1,
 		"hurryCostModifier": 25,
-		"requiredNearbyImprovedResources": ["Scrap","Metal"],
-		"uniques": ["[-1 Food, +2 Production, -1 Gold] from [Scrap] tiles [in this city]",
+		"requiredNearbyImprovedResources": ["Scrap", "Metal"],
+		"uniques": [
+			"[-1 Food, +2 Production, -1 Gold] from [Scrap] tiles [in this city]",
 			"[-1 Food, +2 Production, -1 Gold] from [Metal] tiles [in this city]",
-			"Consumes [1] [Coal]"],		
+			"Consumes [1] [Coal]"
+		],
 		"requiredTech": "Steel"
-	},	
+	},
 	{
-		"name": "Oil Refinery", 
+		"name": "Oil Refinery",
 		"maintenance": 1,
 		"cost": 150,
 		"requiredNearbyImprovedResources": ["Oil"],
 		"hurryCostModifier": 25,
-		"uniques": ["Provides [1] [Oil]",
+		"uniques": [
+			"Provides [1] [Oil]",
 			"[+1 Production] <with [Machine Parts]>",
 			"[-1 Food, +3 Production, -1 Gold] from [Oil] tiles [in this city]",
 			"Consumes [1] [Power]",
-			"Only available <in cities without a [Oil Plant]>"],
+			"Only available <in cities without a [Oil Plant]>"
+		],
 		"requiredTech": "Chemistry"
 	},
 	{
-		"name": "Fuel Depot", 
+		"name": "Fuel Depot",
 		"replaces": "Oil Refinery",
 		"uniqueTo": "Cult of Ignis",
 		"maintenance": 1,
 		"cost": 100,
 		"hurryCostModifier": 25,
-		"uniques": ["[+1 Production, +2 Culture, -1 Gold] from [Oil] tiles [in this city]",
+		"uniques": [
+			"[+1 Production, +2 Culture, -1 Gold] from [Oil] tiles [in this city]",
 			"Provides [1] [Oil]",
 			"[+2 Production, -1 Food] <with [Power]>",
 			"[+1 Production] <with [Machine Parts]>",
-			"Only available <in cities without a [Oil Plant]>"]
+			"Only available <in cities without a [Oil Plant]>"
+		]
 	},
 	{
 		"name": "Oil Plant",
@@ -1601,81 +1845,88 @@
 		"cost": 150,
 		"food": -1,
 		"hurryCostModifier": 25,
-		"uniques": ["Provides [1] [Power]",
+		"uniques": [
+			"Provides [1] [Power]",
 			"[+1 Production] <with [Machine Parts]>",
 			"[-1 Food, +3 Production, -1 Gold] from [Oil] tiles [in this city]",
 			"Consumes [1] [Oil]",
-			"Only available <in cities without a [Oil Refinery]>"],
+			"Only available <in cities without a [Oil Refinery]>"
+		],
 		"requiredTech": "Chemistry"
 	},
 	{
-		"name": "Biofuel Refinery", 
-		"requiredNearbyImprovedResources": ["Cattle","Goats","Horses"],
+		"name": "Biofuel Refinery",
+		"requiredNearbyImprovedResources": ["Cattle", "Goats", "Horses"],
 		"maintenance": 2,
 		"food": -1,
 		"hurryCostModifier": 25,
-		"uniques": ["Provides [1] [Oil]",
-			"Consumes [1] [Power]"],
+		"uniques": ["Provides [1] [Oil]", "Consumes [1] [Power]"],
 		"requiredTech": "Biology"
 	},
 	{
 		"name": "Hydro Plant",
-	//	"cost": 320,
+		// "cost": 320,
 		"hurryCostModifier": 25,
-		"uniques": ["Must be on [River]",
-			"Provides [2] [Power]"],
+		"uniques": ["Must be on [River]", "Provides [2] [Power]"],
 		"requiredTech": "Steam Power"
-	},		
+	},
 	{
 		"name": "Tidal Plant",
-	//	"cost": 320,
+		// "cost": 320,
 		"hurryCostModifier": 25,
-		"uniques": ["Must be next to [Coast]",
-			"Provides [2] [Power]"],
+		"uniques": ["Must be next to [Coast]", "Provides [2] [Power]"],
 		"requiredTech": "Steam Power"
-	},	
+	},
 	{
 		"name": "Coal Plant",
-		"maintenance": 4,	
+		"maintenance": 4,
 		"cost": 250,
 		"hurryCostModifier": 25,
-		"percentStatBonus": {"food": -20},
-		"uniques": ["Provides [8] [Power]",
+		"percentStatBonus": { "food": -20 },
+		"uniques": [
+			"Provides [8] [Power]",
 			"Consumes [1] [Coal]",
-			"Only available <in cities without a [Nuclear Plant]>"],
+			"Only available <in cities without a [Nuclear Plant]>"
+		],
 		"requiredTech": "Steam Power"
-	},	
+	},
 	{
-		"name": "Nuclear Plant",	
+		"name": "Nuclear Plant",
 		"maintenance": 4,
 		"cost": 750,
 		"hurryCostModifier": 33,
-		"uniques": ["Consumes [1] [Uranium]",
+		"uniques": [
+			"Consumes [1] [Uranium]",
 			"Provides [8] [Power]",
 			"[+33]% Production when constructing [Manhattan Project] wonders [in this city]",
 			"[+33]% Production when constructing [Missile] units [in this city]",
-			"Only available <in cities without a [Coal Plant]>"],
+			"Only available <in cities without a [Coal Plant]>"
+		],
 		"requiredTech": "Nuclear Fission"
 	},
 	{
-		"name": "Aluminum Smelter", 
-	//	"food": -1,
+		"name": "Aluminum Smelter",
+		// "food": -1,
 		"maintenance": 1,
-	//	"production": 3,
+		// "production": 3,
 		"hurryCostModifier": 25,
 		"requiredNearbyImprovedResources": ["Aluminum"],
-		"uniques": ["[-1 Food, -1 Gold, +2 Production] from [Aluminum] tiles [in this city]",
-			"Consumes [1] [Power]"],
+		"uniques": [
+			"[-1 Food, -1 Gold, +2 Production] from [Aluminum] tiles [in this city]",
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Manufacturing"
-	},	
+	},
 	{
 		"name": "Desalination Plant",
 		"gold": 8,
 		"hurryCostModifier": 25,
-		"uniques": ["Must be next to [Coast]",
+		"uniques": [
+			"Must be next to [Coast]",
 			"[+1 Gold] <with [Power]>",
 			"Provides [1] [Salt]",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Desalination"
 	},
 	{
@@ -1684,70 +1935,82 @@
 		"uniqueTo": "The Mariners",
 		"gold": 8,
 		"hurryCostModifier": 25,
-		"uniques": ["Must be next to [Coast]",
+		"uniques": [
+			"Must be next to [Coast]",
 			"[+1 Gold] per [5] population [in this city]",
 			"[+1 Gold] <with [Power]>",
 			"Provides [1] [Salt]",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Desalination"
 	},
 	{
 		"name": "Factory",
-	//	"food": -1,
-		"percentStatBonus": {"production": 20},
-		"specialistSlots": {"Engineer": 2},
-	//	"requiredBuilding": "Workshop",
+		// "food": -1,
+		"percentStatBonus": { "production": 20 },
+		"specialistSlots": { "Engineer": 2 },
+		// "requiredBuilding": "Workshop",
 		"maintenance": 2,
 		"hurryCostModifier": 0,
-		"uniques": ["Allows production of advanced troops and vehicles",
+		"uniques": [
+			"Allows production of advanced troops and vehicles",
 			"[+3 Production] <with [Power]>",
 			"[+1 Production] <with [Machine Parts]>",
 			"[+1 Production] from [Machine Parts] tiles [in this city]",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Manufacturing"
-	},	
+	},
 	{
 		"name": "Electronics Production Line",
-		"percentStatBonus": {"production": -5},
+		"percentStatBonus": { "production": -5 },
 		"production": -1,
-		"uniques": ["Provides [1] [Electronics]",
+		"uniques": [
+			"Provides [1] [Electronics]",
 			"Consumes [1] [Power]",
 			"Requires [Monopoly]",
-			"Only available <in cities with a [Factory]>"],
+			"Only available <in cities with a [Factory]>"
+		],
 		"requiredTech": "Electronics"
 	},
 	{
 		"name": "Machinery Production Line",
-		"percentStatBonus": {"production": -5},
+		"percentStatBonus": { "production": -5 },
 		"production": -1,
-		"uniques": ["Provides [1] [Machine Parts]",
+		"uniques": [
+			"Provides [1] [Machine Parts]",
 			"Consumes [1] [Power]",
 			"Requires [Monopoly]",
-			"Only available <in cities with a [Factory]>"],
+			"Only available <in cities with a [Factory]>"
+		],
 		"requiredTech": "Replaceable Parts"
 	},
 	{
 		"name": "Armor Production Line",
-		"percentStatBonus": {"production": -10},
+		"percentStatBonus": { "production": -10 },
 		"production": -3,
-		"uniques": ["[2] free [Tank] units appear",
+		"uniques": [
+			"[2] free [Tank] units appear",
 			"[+66]% Production when constructing [Armor] units [in this city]",
 			"Requires [Collectivism]",
 			"Only available <in cities with a [Factory]>",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Combined Arms"
 	},
 	{
 		"name": "Armaments Production Line",
-		"percentStatBonus": {"production": -10},
+		"percentStatBonus": { "production": -10 },
 		"cityStrength": 5,
 		"production": -3,
-		"uniques": ["Provides [2] [Weapons]",
+		"uniques": [
+			"Provides [2] [Weapons]",
 			"Consumes [1] [Power]",
 			"[Personnel] units gain the [Infantry Weapons] promotion",
 			"[+10]% Production when constructing [Military] units [in this city]",
 			"Only available <in cities with a [Factory]>",
-			"Gain a free [Armory] [in this city]"],
+			"Gain a free [Armory] [in this city]"
+		],
 		"requiredTech": "Munitions"
 	},
 	{
@@ -1755,9 +2018,11 @@
 		"isNationalWonder": true,
 		"cityStrength": 5,
 		"happiness": 3,
-		"uniques": ["[Personnel] units gain the [Drone Recon] promotion",
+		"uniques": [
+			"[Personnel] units gain the [Drone Recon] promotion",
 			"[+10]% Strength <for [Automated] units>",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Avionics"
 	},
 	{
@@ -1766,9 +2031,11 @@
 		"uniqueTo": "Atlas",
 		"isNationalWonder": true,
 		"happiness": 1,
-		"uniques": ["[Low Tech] units gain the [Drone Recon] promotion",
+		"uniques": [
+			"[Low Tech] units gain the [Drone Recon] promotion",
 			"[Personnel] units gain the [Drone Recon] promotion",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Secrets of the Past"
 	},
 	{
@@ -1778,46 +2045,54 @@
 		"isNationalWonder": true,
 		"cityStrength": 5,
 		"happiness": 3,
-		"uniques": ["[Personnel] units gain the [Drone Recon] promotion",
+		"uniques": [
+			"[Personnel] units gain the [Drone Recon] promotion",
 			"[+10]% Strength <for [Automated] units>",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Civil Service"
 	},
 	{
 		"name": "Aerospace Facility",
 		"cityStrength": 10,
 		"production": -3,
-		"uniques": ["Allows production of advanced aircraft",
+		"uniques": [
+			"Allows production of advanced aircraft",
 			"[Air] units gain the [Advanced Weapons] promotion",
 			"[+15]% Production when constructing [Air] units [in this city]",
 			"Only available <in cities with a [Factory]>",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Rocketry"
 	},
 	{
 		"name": "Automated Factory",
-		"percentStatBonus": {"production": 25},
+		"percentStatBonus": { "production": 25 },
 		"production": 5,
 		"maintenance": 3,
-		"uniques": ["[+1 Production] <with [Power]>",
+		"uniques": [
+			"[+1 Production] <with [Power]>",
 			"Only available <in cities with a [Factory]>",
 			"Consumes [1] [Power]",
-			"Consumes [1] [Aluminum]"],
+			"Consumes [1] [Aluminum]"
+		],
 		"requiredTech": "Robotics"
-	},	
+	},
 	{
 		"name": "Work Camp",
-		"percentStatBonus": {"production": 15},
+		"percentStatBonus": { "production": 15 },
 		"production": 1,
-		"specialistSlots": {"Engineer": 1},																																			
+		"specialistSlots": { "Engineer": 1 },
 		"maintenance": 1,
 		"hurryCostModifier": 0,
-		"uniques": ["[+1 Production] <with [Power]>",
+		"uniques": [
+			"[+1 Production] <with [Power]>",
 			"[+2 Production] <with [Slaves]>",
 			"Consumes [1] [Slaves]",
-			"Only available <with [Slaves]>"],
+			"Only available <with [Slaves]>"
+		],
 		"requiredTech": "Construction"
-	},				
+	},
 	/*{
 		"name": "Refugee Center",
 		"replaces": "Work Camp",
@@ -1833,8 +2108,8 @@
 		"name": "Plastics Factory",
 		"food": -1,
 		"production": 2,
-		"specialistSlots": {"Engineer": 1},
-	//	"requiredBuilding": "Workshop",
+		"specialistSlots": { "Engineer": 1 },
+		// "requiredBuilding": "Workshop",
 		"maintenance": 2,
 		"hurryCostModifier": 0,
 		"requiredNearbyImprovedResources": ["Oil"],
@@ -1843,77 +2118,69 @@
 	},
 	{
 		"name": "Plastics Reprocessor",
-	//	"production": 4,
-	//	"percentStatBonus": {"production": 10},
-		"specialistSlots": {"Engineer": 1},
+		// "production": 4,
+		// "percentStatBonus": {"production": 10},
+		"specialistSlots": { "Engineer": 1 },
 		"maintenance": 1,
 		"hurryCostModifier": 0,
 		"requiredNearbyImprovedResources": ["Plastics"],
-		"uniques": ["[+2 Production] from [Plastics] tiles [in this city]",
-			"Consumes [1] [Power]"],
+		"uniques": [
+			"[+2 Production] from [Plastics] tiles [in this city]",
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Plastics Recycling"
 	},
 	{
 		"name": "Metal Reprocessor",
 		"maintenance": 3,
 		"requiredTech": "Advanced Materials",
-		"uniques": ["Provides [2] [Aluminum]","Limited to [5] per Civilization"]
+		"uniques": [
+			"Provides [2] [Aluminum]",
+			"Limited to [5] per Civilization"
+		]
 	},
 	{
 		"name": "Uranium Centrifuge",
 		"maintenance": 3,
 		"requiredTech": "Particle Physics",
-		"uniques": ["Provides [2] [Uranium]","Limited to [5] per Civilization"]
+		"uniques": ["Provides [2] [Uranium]", "Limited to [5] per Civilization"]
 	},
 	{
 		"name": "Carbon Capture",
 		"food": 2,
 		"maintenance": 2,
 		"hurryCostModifier": 0,
-	//	"cannotBeBuiltWith": "Carbon Recapture",
+		// "cannotBeBuiltWith": "Carbon Recapture",
 		"requiredTech": "Atmosphere Remediation"
-	},			
+	},
 	// CUTURE ENDGAME THINGs
-	/*{
-
+	/*
+	{
 		"name": "Carbon Recapture",
 		"food": 1,
 		"maintenance": 3,
 		"hurryCostModifier": 0,
-		"cannotBeBuiltWith": "Carbon Capture",//
-		"requiredResource": "Power",	//power
+		"cannotBeBuiltWith": "Carbon Capture",
+		"requiredResource": "Power",
 		"requiredTech": "Atmosphere Remediation"
-	},	*/
-	{
-		"name": "AI Project",
-		"cost": 3750,
-		"science": 5,
-		"isWonder": true,
-		"uniques": ["[+15]% Strength <for [Automated] units>",
-			"Free [Great Scientist] appears",
-			"Empire enters golden age",
-			"[+15]% Production when constructing [Spaceship part] buildings [in this city]",
-			"Consumes [2] [Power]"],		
-		"percentStatBonus": {"science": 50},
-		"requiredTech": "Artificial Intelligence",
-		"quote": "Let there be light."
-	},	
+	},
+	*/
 	{
 		"name": "Fusion Reactor",
 		"cost": 3750,
 		"isNationalWonder": true,
-		"uniques": ["Provides [8] [Power]",
-			"[+1 Production] [in all cities]"],
+		"uniques": ["Provides [8] [Power]", "[+1 Production] [in all cities]"],
 		"requiredTech": "Future Power"
 	},
-
 	{
 		"name": "Arcology Project",
 		"isNationalWonder": true,
-		"uniques": ["Enables construction of Arcologies",
+		"uniques": [
+			"Enables construction of Arcologies",
 			"Empire enters golden age",
 			"Gain a free [Arcology Dome] [in this city]",
-			"[+10]% Production when constructing [Utopia Project] wonders [in all cities]"],		
+			"[+10]% Production when constructing [Utopia Project] wonders [in all cities]"
+		],
 		"requiredTech": "Future Materials"
 	},
 	{
@@ -1922,61 +2189,56 @@
 		"culture": 1,
 		"happiness": 1,
 		"gold": 1,
-		"percentStatBonus": {"culture": 33, "food": 10, "gold": 10},
+		"percentStatBonus": { "culture": 33, "food": 10, "gold": 10 },
 		"cityStrength": 5,
 		"cityHealth": 25,
 		"requiredTech": "Future Materials",
-		"uniques": ["[10]% Food is carried over after population increases [in this city]",
+		"uniques": [
+			"[10]% Food is carried over after population increases [in this city]",
 			"[+25]% great person generation [in this city]",
 			"[-10]% unhappiness from population [in this city]",
 			"Requires [Arcology Project]",
 			"Requires at least [2] population",
-			"Destroyed when the city is captured"]
-	},
-
-	{
-		"name": "Cryo Project",
-		"isWonder": true,
-		"requiredTech": "Human Genome",
-		"uniques": ["Enables construction of Cryo Vaults"],
-		"quote": "The fact is, these people want to come back to life, and we need them back alive. We can't wait for a better world to come for them. We've got to let them make that better world for all of us."
+			"Destroyed when the city is captured"
+		]
 	},
 	{
 		"name": "Cryo Vault",
 		"cost": 1000,
 		"requiredTech": "Human Genome",
-		"uniques": ["Requires [Cryo Project]",
+		"uniques": [
+			"Requires [Cryo Project]",
 			"Cannot be purchased",
 			"Only available <in cities with a [Medical Lab]>",
 			"Requires at least [5] population",
 			"Unsellable",
 			"Free Great Person",
-			"[+1] population [in this city]"]
+			"[+1] population [in this city]"
+		]
 	},
+	// water purifier
+	// desalination plants -coal or nuke
+	// computer centre
 
-
-	//water purifier
-	//desalination plants -coal or nuke
-	//computer centre
-	
-	//COASTAL
+	// Coastal buildings
 	{
 		"name": "Fish Farm",
 		"food": 4,
-	//	"maintenance": 1,
+		// "maintenance": 1,
 		"hurryCostModifier": 25,
-	//	"requiredNearbyImprovedResources": ["Fish"],
+		// "requiredNearbyImprovedResources": ["Fish"],
 		"requiredTech": "Ecology",
 		"uniques": ["Must be next to [Coast]"]
 	},
-
 	{
 		"name": "Harbor",
-	//	"maintenance": 2,
-	//	"hurryCostModifier": 25,
-		"uniques": ["[+10]% Production when constructing [Water] units [in this city]",
+		// "maintenance": 2,
+		// "hurryCostModifier": 25,
+		"uniques": [
+			"[+10]% Production when constructing [Water] units [in this city]",
 			"Connects trade routes over water",
-			"Must be next to [Coast]"],
+			"Must be next to [Coast]"
+		],
 		"requiredTech": "Astronomy"
 	},
 	{
@@ -1984,35 +2246,41 @@
 		"uniqueTo": "The Mariners",
 		"replaces": "Harbor",
 		"gold": 1,
-		"uniques": ["[+10]% Production when constructing [Water] units [in this city]",
+		"uniques": [
+			"[+10]% Production when constructing [Water] units [in this city]",
 			"New [Water] units start with [15] Experience [in this city]",
 			"Connects trade routes over water",
-			"Must be next to [Coast]"],
+			"Must be next to [Coast]"
+		],
 		"requiredTech": "Astronomy"
 	},
 	{
 		"name": "Seaport",
 		"hurryCostModifier": 25,
-	//	"maintenance": 2,"+1 production and gold from all sea resources worked by the city",
-		"uniques": ["[+1 Production] from [Water resource] tiles [in this city]",
+		// "maintenance": 2,
+		"uniques": [
+			// "[+1 Production, +1 Gold] from [Water resource] tiles [in this city]",
+			"[+1 Production] from [Water resource] tiles [in this city]",
 			"Must be next to [Coast]",
 			"[+15]% Production when constructing [Water] units [in this city]",
-			"Only available <in cities with a [Harbor]>"],
+			"Only available <in cities with a [Harbor]>"
+		],
 		"requiredTech": "Manufacturing"
 	},
 	{
 		"name": "Ocean Seeder",
 		"hurryCostModifier": 25,
 		"maintenance": 2,
-		"uniques": ["Must be next to [Coast]",
+		"uniques": [
+			"Must be next to [Coast]",
 			"[+1 Food] from [Coast] tiles [in this city]",
 			"[+1 Food] from [Ocean] tiles [in this city]",
-			"Consumes [1] [Power]"],
+			"Consumes [1] [Power]"
+		],
 		"requiredTech": "Ocean Remediation"
 	},
-	
-	// religion
 
+	// Religion buildings
 	{
 		"name": "Shrine",
 		"faith": 1,
@@ -2027,8 +2295,10 @@
 		"faith": 1,
 		"cost": 40,
 		"requiredTech": "Secrets of the Past",
-		"uniques": ["Hidden when religion is disabled",
-			"[+1 Faith] from [Oil] tiles [in this city]"]
+		"uniques": [
+			"Hidden when religion is disabled",
+			"[+1 Faith] from [Oil] tiles [in this city]"
+		]
 	},
 	{
 		"name": "Monastery",
@@ -2036,7 +2306,10 @@
 		"maintenance": 1,
 		"hurryCostModifier": 25,
 		"requiredTech": "Education",
-		"uniques": ["Only available <in cities with a [Shrine]>","Hidden when religion is disabled"]
+		"uniques": [
+			"Only available <in cities with a [Shrine]>",
+			"Hidden when religion is disabled"
+		]
 	},
 	{
 		"name": "Pyramid",
@@ -2053,7 +2326,7 @@
 		"faith": 1,
 		"happiness": 1,
 		"food": 2,
-		"specialistSlots": {"Farmer": 1},
+		"specialistSlots": { "Farmer": 1 },
 		"uniques": ["Unbuildable", "Hidden when religion is disabled"]
 	},
 	{
@@ -2067,29 +2340,27 @@
 		"uniques": ["Unbuildable", "Hidden when religion is disabled"]
 	},
 
-//																																	unbuildable uniques																..
-
-
-	
+	// Unbuildable uniques
 	{
 		"name": "Archive of the Arts",
 		"uniqueTo": "The Archive",
 		"cost": 1,
 		"culture": 5,
-        "science": 1,
+		"science": 1,
 		"happiness": 1,
-		"greatPersonPoints": {"Great Administrator": 2},
-		"uniques": ["[+50]% Golden Age length",
-			"Provides [1] [Power]"]
-	},	
+		"greatPersonPoints": { "Great Administrator": 2 },
+		"uniques": ["[+50]% Golden Age length", "Provides [1] [Power]"]
+	},
 	{
 		"name": "Encylopedia",
 		"uniqueTo": "The Archive",
 		"replaces": "Monument",
 		"cost": 1,
 		"culture": 3,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Reveals the entire map"]
+		"uniques": [
+			"Will not be displayed in Civilopedia",
+			"Reveals the entire map"
+		]
 	},
 	{
 		"name": "Homestead",
@@ -2097,31 +2368,36 @@
 		"replaces": "Monument",
 		"cost": 1,
 		"culture": 5,
-		"uniques": ["Will not be displayed in Civilopedia",
+		"uniques": [
+			"Will not be displayed in Civilopedia",
 			"Reveals the entire map",
 			"Provides [1] [Oil]",
 			"Provides [1] [Power]",
-			"Provides [1] [Weapons]"]
+			"Provides [1] [Weapons]"
+		]
 	},
-
 	{
 		"name": "Nuclear Storage",
 		"uniqueTo": "Devil's Canyon",
 		"replaces": "Monument",
 		"gold": 5,
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Reveals the entire map"]
+		"uniques": [
+			"Will not be displayed in Civilopedia",
+			"Reveals the entire map"
+		]
 	},
 	{
 		"name": "Devil's Nuclear Plant",
 		"uniqueTo": "Devil's Canyon",
 		"replaces": "Nuclear Plant",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
+		"uniques": [
+			"Will not be displayed in Civilopedia",
 			"Provides [8] [Power]",
 			"[+33]% Production when constructing [Missile] units [in this city]",
-			"Only available <in cities without a [Coal Plant]>"]
+			"Only available <in cities without a [Coal Plant]>"
+		]
 	},
 	{
 		"name": "Silk Road",
@@ -2129,10 +2405,12 @@
 		"replaces": "Monument",
 		"cost": 1,
 		"culture": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
+		"uniques": [
+			"Will not be displayed in Civilopedia",
 			"Reveals the entire map",
 			"Provides [1] [Oil]",
-			"Provides [1] [Weapons]"]
+			"Provides [1] [Weapons]"
+		]
 	},
 	{
 		"name": "Paradise Alley",
@@ -2147,10 +2425,10 @@
 		"cost": 1,
 		"faith": 5,
 		"culture": 1,
-        "science": 3,
+		"science": 3,
 		"happiness": 2,
-		"greatPersonPoints": {"Great Scientist": 2}
-	},	
+		"greatPersonPoints": { "Great Scientist": 2 }
+	},
 	{
 		"name": "Divine Knowledge",
 		"uniqueTo": "Order of Jerome",
@@ -2158,50 +2436,47 @@
 		"cost": 1,
 		"cityHealth": 25,
 		"culture": 3,
-		"uniques": ["Will not be displayed in Civilopedia",
+		"uniques": [
+			"Will not be displayed in Civilopedia",
 			"Reveals the entire map",
-			"Provides [1] [Power]"]
+			"Provides [1] [Power]"
+		]
 	},
 	{
 		"name": "Arroyo Notlibrary",
 		"uniqueTo": "Arroyo",
 		"replaces": "Library",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Arroyo Notfactory",
 		"uniqueTo": "Arroyo",
 		"replaces": "Factory",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Arroyo Notcoalplant",
 		"uniqueTo": "Arroyo",
 		"replaces": "Coal Plant",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Arroyo Nothydroplant",
 		"uniqueTo": "Arroyo",
 		"replaces": "Hydro Plant",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Arroyo Nottidalplant",
 		"uniqueTo": "Arroyo",
 		"replaces": "Tidal Plant",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
-	},	
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
+	},
 	{
 		"name": "Arroyo",
 		"uniqueTo": "Arroyo",
@@ -2210,49 +2485,46 @@
 		"cityHealth": 50,
 		"food": 2,
 		"culture": 10,
-		"happiness": 2,		
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Reveals the entire map"]
+		"happiness": 2,
+		"uniques": [
+			"Will not be displayed in Civilopedia",
+			"Reveals the entire map"
+		]
 	},
 	{
 		"name": "Ghost Notlibrary",
 		"uniqueTo": "Ghost Mountain",
 		"replaces": "Library",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Ghost Notfactory",
 		"uniqueTo": "Ghost Mountain",
 		"replaces": "Factory",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Ghost Notcoalplant",
 		"uniqueTo": "Ghost Mountain",
 		"replaces": "Coal Plant",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Ghost Nothydroplant",
 		"uniqueTo": "Ghost Mountain",
 		"replaces": "Hydro Plant",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Ghost Nottidalplant",
 		"uniqueTo": "Ghost Mountain",
 		"replaces": "Tidal Plant",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Ghost Mountain",
@@ -2262,22 +2534,25 @@
 		"cityHealth": 100,
 		"food": 2,
 		"culture": 10,
-		"happiness": 2,		
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Reveals the entire map"]
+		"happiness": 2,
+		"uniques": [
+			"Will not be displayed in Civilopedia",
+			"Reveals the entire map"
+		]
 	},
-	
 	{
 		"name": "Alma Air Base",
 		"uniqueTo": "Almaty",
 		"cityStrength": 10,
 		"cityHealth": 50,
 		"cost": 1,
-        "science": 1,
-        "production": 3,
-		"uniques": ["Provides [2] [Weapons]",
+		"science": 1,
+		"production": 3,
+		"uniques": [
+			"Provides [2] [Weapons]",
 			"Must not be on [Hill]",
-			"Only available <in cities without a [Alma Tank Depot]>"]
+			"Only available <in cities without a [Alma Tank Depot]>"
+		]
 	},
 	{
 		"name": "Alma Tank Depot",
@@ -2285,10 +2560,12 @@
 		"cityStrength": 5,
 		"cityHealth": 100,
 		"cost": 1,
-        "science": 1,
-        "production": 3,
-		"uniques": ["Provides [2] [Weapons]",
-			"Only available <in cities without a [Alma Air Base]>"]
+		"science": 1,
+		"production": 3,
+		"uniques": [
+			"Provides [2] [Weapons]",
+			"Only available <in cities without a [Alma Air Base]>"
+		]
 	},
 	{
 		"name": "Alma Base",
@@ -2297,33 +2574,39 @@
 		"cost": 1,
 		"cityHealth": 100,
 		"culture": 5,
-		"uniques": ["Will not be displayed in Civilopedia",
+		"uniques": [
+			"Will not be displayed in Civilopedia",
 			"Reveals the entire map",
-			"Free [Howitzer] appears"]
-	},	
+			"Free [Howitzer] appears"
+		]
+	},
 	{
 		"name": "Alma Oil Depot",
 		"culture": 1,
 		"happiness": 5,
-		"specialistSlots": {"Engineer": 2},
-		"maintenance": 1,	
-		"uniques": ["Provides [1] [Oil]",
+		"specialistSlots": { "Engineer": 2 },
+		"maintenance": 1,
+		"uniques": [
+			"Provides [1] [Oil]",
 			"Provides [1] [Power]",
-			"Will not be displayed in Civilopedia"],
-		"cost": 40,		
+			"Will not be displayed in Civilopedia"
+		],
+		"cost": 40,
 		"replaces": "Town Hall",
 		"uniqueTo": "Almaty",
 		"requiredTech": "Manufacturing"
-	},	
+	},
 	{
 		"name": "Salvage Tank Depot",
 		"requiredTech": "Engineering",
 		"isWonder": true,
 		"cost": 75,
-        "science": 1,
-        "production": -3,
-		"uniques": ["Free [Modern Armor] appears",
-			"Only available <in cities with a [Alma Tank Depot]>"],
+		"science": 1,
+		"production": -3,
+		"uniques": [
+			"Free [Modern Armor] appears",
+			"Only available <in cities with a [Alma Tank Depot]>"
+		],
 		"quote": "To a man with a hammer, everything looks like a nail."
 	},
 	{
@@ -2331,11 +2614,13 @@
 		"requiredTech": "Manufacturing",
 		"isWonder": true,
 		"cost": 60,
-        "science": 1,
-        "production": -3,
-		"uniques": ["Free [Bomber] appears",
+		"science": 1,
+		"production": -3,
+		"uniques": [
+			"Free [Bomber] appears",
 			"Only available <in cities with a [Alma Air Base]>",
-			"Only available <in cities without a [Salvage Helicopter]>"],
+			"Only available <in cities without a [Salvage Helicopter]>"
+		],
 		"quote": "For once you have tasted flight, you will forever walk the earth with your eyes turned skyward. For there you have been, and there you will always long to return."
 	},
 	{
@@ -2343,11 +2628,13 @@
 		"requiredTech": "Engineering",
 		"isWonder": true,
 		"cost": 75,
-        "science": 1,
-        "production": -3,
-		"uniques": ["Free [Helicopter] appears",
+		"science": 1,
+		"production": -3,
+		"uniques": [
+			"Free [Helicopter] appears",
 			"Only available <in cities with a [Alma Air Base]>",
-			"Only available <in cities without a [Salvage Bomber]>"],
+			"Only available <in cities without a [Salvage Bomber]>"
+		],
 		"quote": "Helicopters don't fly, they vibrate so badly the ground rejects them."
 	},
 	{
@@ -2356,36 +2643,41 @@
 		"replaces": "Monument",
 		"cost": 1,
 		"culture": 2,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Reveals the entire map"]
+		"uniques": [
+			"Will not be displayed in Civilopedia",
+			"Reveals the entire map"
+		]
 	},
 	{
 		"name": "Trader's Hub",
 		"uniqueTo": "The Hub",
 		"cost": 1,
-		"uniques": ["Provides [2] [Oil]",
+		"uniques": [
+			"Provides [2] [Oil]",
 			"Provides [2] [Weapons]",
-			"Provides [2] [Slaves]"]
+			"Provides [2] [Slaves]"
+		]
 	},
 	{
 		"name": "Hub Notfactory",
 		"uniqueTo": "The Hub",
 		"replaces": "Factory",
 		"cost": 1,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Unbuildable"]
+		"uniques": ["Will not be displayed in Civilopedia", "Unbuildable"]
 	},
 	{
 		"name": "Hub Work Camp",
-		"uniqueTo":"The Hub",
-		"replaces":	"Work Camp",
-		"percentStatBonus": {"production": 15},
+		"uniqueTo": "The Hub",
+		"replaces": "Work Camp",
+		"percentStatBonus": { "production": 15 },
 		"production": 1,
-		"specialistSlots": {"Engineer": 1},																																			
+		"specialistSlots": { "Engineer": 1 },
 		"maintenance": 1,
 		"hurryCostModifier": 0,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Provides [1] [Slaves]"],
+		"uniques": [
+			"Will not be displayed in Civilopedia",
+			"Provides [1] [Slaves]"
+		],
 		"requiredTech": "Construction"
 	},
 	{
@@ -2394,8 +2686,10 @@
 		"replaces": "Monument",
 		"cost": 1,
 		"culture": 2,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Reveals the entire map"]
+		"uniques": [
+			"Will not be displayed in Civilopedia",
+			"Reveals the entire map"
+		]
 	},
 	{
 		"name": "Grand Temple",
@@ -2412,8 +2706,10 @@
 		"replaces": "Monument",
 		"cost": 1,
 		"culture": 2,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Reveals the entire map"]
+		"uniques": [
+			"Will not be displayed in Civilopedia",
+			"Reveals the entire map"
+		]
 	},
 	{
 		"name": "Iron Rod Stockpile",
@@ -2430,8 +2726,10 @@
 		"culture": 2,
 		"gold": 2,
 		"food": 2,
-		"uniques": ["Will not be displayed in Civilopedia",
-			"Reveals the entire map"]
+		"uniques": [
+			"Will not be displayed in Civilopedia",
+			"Reveals the entire map"
+		]
 	},
 	{
 		"name": "Land Value Tax",
@@ -2439,5 +2737,4 @@
 		"cost": 1,
 		"uniques": ["[+1 Gold] from [Land] tiles [in this city]"]
 	}
-
 ]

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -26,7 +26,7 @@
 			"Gain a free [Deep Larder] [in this city]"
 		],
 		"quote": "An armed society is a polite society.",
-		"civilopediaText": [{ "text": "An armed society is a polite society."}]
+		"civilopediaText": [{ "text": "An armed society is a polite society." }]
 	},
 	{
 		"name": "Ark One",
@@ -45,7 +45,7 @@
 			"Gain a free [Food Store] [in this city]"
 		],
 		"quote": "While your deposit clears, you may want to read through this guide for potential residents. The Ark One shelter comprises a unique set of secure luxury accomodation based within a former military facility. In addition to their private living space, residents will have access to a complete set of facilities including two restaurants, a cinema, a bowling alley, and a fitness area with gym, spa, sauna and pool. The Ark One shelter is protected by a world-class professional security company, and is hardened to resist a nuclear strike and any armed attack.",
-		"civilopediaText": [{ "text": "While your deposit clears, you may want to read through this guide for potential residents. The Ark One shelter comprises a unique set of secure luxury accomodation based within a former military facility. In addition to their private living space, residents will have access to a complete set of facilities including two restaurants, a cinema, a bowling alley, and a fitness area with gym, spa, sauna and pool. The Ark One shelter is protected by a world-class professional security company, and is hardened to resist a nuclear strike and any armed attack."}]
+		"civilopediaText": [{ "text": "While your deposit clears, you may want to read through this guide for potential residents. The Ark One shelter comprises a unique set of secure luxury accomodation based within a former military facility. In addition to their private living space, residents will have access to a complete set of facilities including two restaurants, a cinema, a bowling alley, and a fitness area with gym, spa, sauna and pool. The Ark One shelter is protected by a world-class professional security company, and is hardened to resist a nuclear strike and any armed attack." }]
 	},
 	{
 		"name": "Atlas Refuge",
@@ -62,7 +62,7 @@
 			"Gain a free [Food Store] [in this city]"
 		],
 		"quote": "At the Refuge, I am creating more than a town, more even than a polity; it is a new world, where individuals will be free to act without the burden of taxation or the specter of injustice. Here, I have created a truly voluntary society, where the citizens associate in rational self interest; from love, not from fear of punishment. I have sent you this invitation because you have greatness within you; think of all you have achieved in your life, and how much more you could do, if you were not held back. Choose something different. Choose Atlas.",
-		"civilopediaText": [{ "text": "At the Refuge, I am creating more than a town, more even than a polity; it is a new world, where individuals will be free to act without the burden of taxation or the specter of injustice. Here, I have created a truly voluntary society, where the citizens associate in rational self interest; from love, not from fear of punishment. I have sent you this invitation because you have greatness within you; think of all you have achieved in your life, and how much more you could do, if you were not held back. Choose something different. Choose Atlas."}]
+		"civilopediaText": [{ "text": "At the Refuge, I am creating more than a town, more even than a polity; it is a new world, where individuals will be free to act without the burden of taxation or the specter of injustice. Here, I have created a truly voluntary society, where the citizens associate in rational self interest; from love, not from fear of punishment. I have sent you this invitation because you have greatness within you; think of all you have achieved in your life, and how much more you could do, if you were not held back. Choose something different. Choose Atlas." }]
 	},
 	{
 		"name": "Eagle Rock Complex",
@@ -82,7 +82,7 @@
 			"Gain a free [Food Store] [in this city]"
 		],
 		"quote": "We are here to protect the people, and we will do it here. Here we make our stand against anarchy and tyranny. Here, we will once again establish freedom and order. This is the oath we have taken, and we will keep that oath.",
-		"civilopediaText": [{ "text": "We are here to protect the people, and we will do it here. Here we make our stand against anarchy and tyranny. Here, we will once again establish freedom and order. This is the oath we have taken, and we will keep that oath."}]
+		"civilopediaText": [{ "text": "We are here to protect the people, and we will do it here. Here we make our stand against anarchy and tyranny. Here, we will once again establish freedom and order. This is the oath we have taken, and we will keep that oath." }]
 	},
 	{
 		"name": "Forum",
@@ -96,7 +96,7 @@
 			"Can only be built [in capital]"
 		],
 		"quote": "Whatsoever any man either doth or saith, thou must be good; not for any man's sake, but for thine own nature's sake; as if either gold, or the emerald, or purple, should ever be saying to themselves, Whatsoever any man either doth or saith, I must still be an emerald, and I must keep my colour.",
-		"civilopediaText": [{ "text": "Whatsoever any man either doth or saith, thou must be good; not for any man's sake, but for thine own nature's sake; as if either gold, or the emerald, or purple, should ever be saying to themselves, Whatsoever any man either doth or saith, I must still be an emerald, and I must keep my colour."}]
+		"civilopediaText": [{ "text": "Whatsoever any man either doth or saith, thou must be good; not for any man's sake, but for thine own nature's sake; as if either gold, or the emerald, or purple, should ever be saying to themselves, Whatsoever any man either doth or saith, I must still be an emerald, and I must keep my colour." }]
 	},
 	{
 		"name": "Temple",
@@ -113,7 +113,7 @@
 			"Gain a free [Fuel Depot] [in this city]"
 		],
 		"quote": "Be thy hands, anointed, with holy oil.\nBe thy breast, anointed, with holy oil.\nBe thy head, anointed, with holy oil.\nAs kings, priests, and prophets were anointed.\nAnd as Solomon was anointed king by Zadok the priest and Nathan the prophet, so be you anointed.",
-		"civilopediaText": [{ "text": "Be thy hands, anointed, with holy oil.\nBe thy breast, anointed, with holy oil.\nBe thy head, anointed, with holy oil.\nAs kings, priests, and prophets were anointed.\nAnd as Solomon was anointed king by Zadok the priest and Nathan the prophet, so be you anointed."}]
+		"civilopediaText": [{ "text": "Be thy hands, anointed, with holy oil.\nBe thy breast, anointed, with holy oil.\nBe thy head, anointed, with holy oil.\nAs kings, priests, and prophets were anointed.\nAnd as Solomon was anointed king by Zadok the priest and Nathan the prophet, so be you anointed." }]
 	},
 	{
 		"name": "Peace Memorial",
@@ -128,7 +128,7 @@
 			"Gain a free [Monument] [in this city]"
 		],
 		"quote": "Lasting peace is sought, it is essential to adopt international measures to improve the lot of the masses. The welfare of the entire human race must replace hunger and oppression. People of the world must be taught to give up envy, avarice and rancour.",
-		"civilopediaText": [{ "text": "Lasting peace is sought, it is essential to adopt international measures to improve the lot of the masses. The welfare of the entire human race must replace hunger and oppression. People of the world must be taught to give up envy, avarice and rancour."}]
+		"civilopediaText": [{ "text": "Lasting peace is sought, it is essential to adopt international measures to improve the lot of the masses. The welfare of the entire human race must replace hunger and oppression. People of the world must be taught to give up envy, avarice and rancour." }]
 	},
 	{
 		"name": "Longhouse",
@@ -146,7 +146,7 @@
 			"Gain a free [Salvage Yard] [in this city]"
 		],
 		"quote": "Now there are no doors left in the houses for they have all been kicked off. So, also, there are no fires in the village and have not been for many days. Now the men full of strong drink have trodden in the fireplaces. They alone track there and there are no fires and their footprints are in all the fireplaces.",
-		"civilopediaText": [{ "text": "Now there are no doors left in the houses for they have all been kicked off. So, also, there are no fires in the village and have not been for many days. Now the men full of strong drink have trodden in the fireplaces. They alone track there and there are no fires and their footprints are in all the fireplaces."}]
+		"civilopediaText": [{ "text": "Now there are no doors left in the houses for they have all been kicked off. So, also, there are no fires in the village and have not been for many days. Now the men full of strong drink have trodden in the fireplaces. They alone track there and there are no fires and their footprints are in all the fireplaces." }]
 	},
 	{
 		"name": "The Great Lighthouse",
@@ -161,7 +161,7 @@
 			"[+1] Sight <for [Water] units>"
 		],
 		"quote": "Brightly beams our father's mercy\nFrom his lighthouse evermore\nBut to us he gives the keeping\nOf the lights along the shore.",
-		"civilopediaText": [{ "text": "Brightly beams our father's mercy\nFrom his lighthouse evermore\nBut to us he gives the keeping\nOf the lights along the shore."}]
+		"civilopediaText": [{ "text": "Brightly beams our father's mercy\nFrom his lighthouse evermore\nBut to us he gives the keeping\nOf the lights along the shore." }]
 	},
 	{
 		"name": "Great Mosque",
@@ -179,7 +179,7 @@
 			"Gain a free [Mosque] [in this city]"
 		],
 		"quote": "We declare our right on this earth to be a human being, to be respected as a human being, to be given the rights of a human being in this society, on this earth, in this day, which we intend to bring into existence by any means necessary.",
-		"civilopediaText": [{ "text": "We declare our right on this earth to be a human being, to be respected as a human being, to be given the rights of a human being in this society, on this earth, in this day, which we intend to bring into existence by any means necessary."}]
+		"civilopediaText": [{ "text": "We declare our right on this earth to be a human being, to be respected as a human being, to be given the rights of a human being in this society, on this earth, in this day, which we intend to bring into existence by any means necessary." }]
 	},
 	{
 		"name": "Clan Hideout",
@@ -194,7 +194,7 @@
 			"Gain a free [Food Store] [in this city]"
 		],
 		"quote": "If you would keep your secret from an enemy, tell it not to a friend.",
-		"civilopediaText": [{ "text": "If you would keep your secret from an enemy, tell it not to a friend."}]
+		"civilopediaText": [{ "text": "If you would keep your secret from an enemy, tell it not to a friend." }]
 	},
 
 	// Cultural victory
@@ -223,7 +223,7 @@
 			"Triggers a global alert upon build start"
 		],
 		"quote": "United we stand. Divided we fall.",
-		"civilopediaText": [{ "text": "United we stand. Divided we fall."}]
+		"civilopediaText": [{ "text": "United we stand. Divided we fall." }]
 	},
 
 	// Government buildings
@@ -234,7 +234,7 @@
 		"uniques": [
 			"[+1 Culture] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
-			"Requires [Search for Survivors]",
+			"Only available <if [Search for Survivors] is constructed>",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Council]>",
 			"Destroyed when the city is captured"
@@ -247,7 +247,7 @@
 		"uniques": [
 			"[+10]% growth [in all cities]",
 			"[+5]% Production when constructing [All] buildings [in this city]",
-			"Requires [Search for Survivors]",
+			"Only available <if [Search for Survivors] is constructed>",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Congress]>",
 			"Destroyed when the city is captured"
@@ -262,7 +262,7 @@
 		"uniques": [
 			"[+1 Science, +1 Culture] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
-			"Requires [Search for Survivors]",
+			"Only available <if [Search for Survivors] is constructed>",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Defense Committee]>",
 			"Destroyed when the city is captured"
@@ -277,7 +277,7 @@
 		"uniques": [
 			"[+15]% Strength <for [All] units> <when fighting in [Friendly Land] tiles>",
 			"[+20]% Production when constructing [Military] units [in all cities]",
-			"Requires [Search for Survivors]",
+			"Only available <if [Search for Survivors] is constructed>",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Citizens' Assembly]>",
 			"Destroyed when the city is captured"
@@ -292,7 +292,7 @@
 		"uniques": [
 			"[+1 Culture, +1 Gold] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
-			"Requires [Search for Survivors]",
+			"Only available <if [Search for Survivors] is constructed>",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Board of Directors]>",
 			"Destroyed when the city is captured"
@@ -307,7 +307,7 @@
 		"uniques": [
 			"[+1 Gold] from every [Town Hall]",
 			"Cost of purchasing items in cities reduced by [20]%",
-			"Requires [Search for Survivors]",
+			"Only available <if [Search for Survivors] is constructed>",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Shareholders' Fund]>",
 			"Destroyed when the city is captured"
@@ -322,7 +322,7 @@
 		"uniques": [
 			"[+1 Science, +1 Gold] per [4] population [in all cities]",
 			"[-10]% unhappiness from population [in all cities]",
-			"Requires [Search for Survivors]",
+			"Only available <if [Search for Survivors] is constructed>",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Think Tank]>",
 			"Destroyed when the city is captured"
@@ -337,7 +337,7 @@
 		"uniques": [
 			"Production to science conversion in cities increased by 33%",
 			"[+10]% Production when constructing [Science] buildings [in all cities]",
-			"Requires [Search for Survivors]",
+			"Only available <if [Search for Survivors] is constructed>",
 			"Can only be built [in capital]",
 			"Only available <in cities without a [Freedom Foundation]>",
 			"Destroyed when the city is captured"
@@ -560,7 +560,7 @@
 		],
 		"requiredTech": "Satellites",
 		"quote": "I must down to the seas again, to the lonely sea and the sky,\nAnd all I ask is a tall ship and a star to steer her by.",
-		"civilopediaText": [{ "text": "I must down to the seas again, to the lonely sea and the sky,\nAnd all I ask is a tall ship and a star to steer her by."}]
+		"civilopediaText": [{ "text": "I must down to the seas again, to the lonely sea and the sky,\nAnd all I ask is a tall ship and a star to steer her by." }]
 	},
 	{
 		"name": "Cryo Project",
@@ -568,7 +568,7 @@
 		"requiredTech": "Human Genome",
 		"uniques": ["Enables construction of Cryo Vaults"],
 		"quote": "The fact is, these people want to come back to life, and we need them back alive. We can't wait for a better world to come for them. We've got to let them make that better world for all of us.",
-		"civilopediaText": [{ "text": "The fact is, these people want to come back to life, and we need them back alive. We can't wait for a better world to come for them. We've got to let them make that better world for all of us."}]
+		"civilopediaText": [{ "text": "The fact is, these people want to come back to life, and we need them back alive. We can't wait for a better world to come for them. We've got to let them make that better world for all of us." }]
 	},
 
 	// Normal wonders
@@ -582,7 +582,7 @@
 			"[+2 Food] [in all cities]"
 		],
 		"quote": "When you hear the air attack warning, you and your family must take cover...",
-		"civilopediaText": [{ "text": "When you hear the air attack warning, you and your family must take cover..."}]
+		"civilopediaText": [{ "text": "When you hear the air attack warning, you and your family must take cover..." }]
 	},
 	{
 		"name": "Public Broadcast",
@@ -594,7 +594,7 @@
 			"Only available <in cities with a [Broadcast Tower]>"
 		],
 		"quote": "When the immediate danger has passed the sirens will sound a steady note. The all clear message will also be given on this wavelength.",
-		"civilopediaText": [{ "text": "When the immediate danger has passed the sirens will sound a steady note. The all clear message will also be given on this wavelength."}]
+		"civilopediaText": [{ "text": "When the immediate danger has passed the sirens will sound a steady note. The all clear message will also be given on this wavelength." }]
 	},
 	{
 		"name": "Skunkworks",
@@ -609,7 +609,7 @@
 		],
 		"requiredTech": "Decryption",
 		"quote": "Many times a customer would come to the Skunk Works with a request and on a handshake the project would begin, no contracts in place, no official submittal process.",
-		"civilopediaText": [{ "text": "Many times a customer would come to the Skunk Works with a request and on a handshake the project would begin, no contracts in place, no official submittal process."}]
+		"civilopediaText": [{ "text": "Many times a customer would come to the Skunk Works with a request and on a handshake the project would begin, no contracts in place, no official submittal process." }]
 	},
 	{
 		"name": "Supercollider",
@@ -624,7 +624,7 @@
 		"percentStatBonus": { "science": 50 },
 		"requiredTech": "Particle Physics",
 		"quote": "God does not play dice.",
-		"civilopediaText": [{ "text": "God does not play dice."}]
+		"civilopediaText": [{ "text": "God does not play dice." }]
 	},
 	{
 		"name": "AI Project",
@@ -641,7 +641,7 @@
 		"percentStatBonus": { "science": 50 },
 		"requiredTech": "Artificial Intelligence",
 		"quote": "Let there be light.",
-		"civilopediaText": [{ "text": "Let there be light."}]
+		"civilopediaText": [{ "text": "Let there be light." }]
 	},
 
 	// Domination wonders
@@ -657,7 +657,7 @@
 			"Only available <in cities with a [Alma Tank Depot]>"
 		],
 		"quote": "To a man with a hammer, everything looks like a nail.",
-		"civilopediaText": [{ "text": "To a man with a hammer, everything looks like a nail."}]
+		"civilopediaText": [{ "text": "To a man with a hammer, everything looks like a nail." }]
 	},
 	{
 		"name": "Salvage Bomber",
@@ -672,7 +672,7 @@
 			"Only available <in cities without a [Salvage Helicopter]>"
 		],
 		"quote": "For once you have tasted flight, you will forever walk the earth with your eyes turned skyward. For there you have been, and there you will always long to return.",
-		"civilopediaText": [{ "text": "For once you have tasted flight, you will forever walk the earth with your eyes turned skyward. For there you have been, and there you will always long to return."}]
+		"civilopediaText": [{ "text": "For once you have tasted flight, you will forever walk the earth with your eyes turned skyward. For there you have been, and there you will always long to return." }]
 	},
 	{
 		"name": "Salvage Helicopter",
@@ -687,7 +687,7 @@
 			"Only available <in cities without a [Salvage Bomber]>"
 		],
 		"quote": "Helicopters don't fly, they vibrate so badly the ground rejects them.",
-		"civilopediaText": [{ "text": "Helicopters don't fly, they vibrate so badly the ground rejects them."}]
+		"civilopediaText": [{ "text": "Helicopters don't fly, they vibrate so badly the ground rejects them." }]
 	},
 
 	// Natural Wonder uniques
@@ -727,7 +727,7 @@
 		],
 		// "requiredTech": "Secrets of the Past",
 		"quote": "Our legends tell of weapons, wielded by kings of old; crafted by evil wizards, unholy to behold...",
-		"civilopediaText": [{ "text": "Our legends tell of weapons, wielded by kings of old; crafted by evil wizards, unholy to behold..."}]
+		"civilopediaText": [{ "text": "Our legends tell of weapons, wielded by kings of old; crafted by evil wizards, unholy to behold..." }]
 	},
 	{
 		"name": "Nuclear Waste Museum",
@@ -752,7 +752,7 @@
 		"quote": "Sending this message was important to us.\nWe considered ourselves to be a powerful culture.\nThis place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.\nWhat is here was dangerous and repulsive to us.\nThis message is a warning about danger.\nThe danger is still present, in your time, as it was in ours.",
 		"civilopediaText": [
 			{ "text": "DO NOT DO THIS", "color": "#FF0000" },
-			{ "text": "Sending this message was important to us.\nWe considered ourselves to be a powerful culture.\nThis place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.\nWhat is here was dangerous and repulsive to us.\nThis message is a warning about danger.\nThe danger is still present, in your time, as it was in ours."}
+			{ "text": "Sending this message was important to us.\nWe considered ourselves to be a powerful culture.\nThis place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.\nWhat is here was dangerous and repulsive to us.\nThis message is a warning about danger.\nThe danger is still present, in your time, as it was in ours." }
 		]
 	},
 	{
@@ -767,7 +767,7 @@
 			"[+25]% growth [in all cities]"
 		],
 		"quote": "What about us? What about all the plans that ended in disaster?",
-		"civilopediaText": [{ "text": "What about us? What about all the plans that ended in disaster?"}]
+		"civilopediaText": [{ "text": "What about us? What about all the plans that ended in disaster?" }]
 	},
 	{
 		"name": "Distribute Soft Drinks",
@@ -780,7 +780,7 @@
 			"Only available <in cities without a [Produce Soft Drinks]>"
 		],
 		"quote": "E-NERGY ULTRA BRIGHT ZERO EMISSION STEALTH\n(Per 500ml Energy 11kCal(1%**)\nNiacin 43mg(266%**)\nPANTHOTENIC ACID 21mg (350%**)\nCaffeine-B 150mg (600%**)**%RDA)\nZERO SUGAR - JUST AS PUMPED!\nIn collaboration with Gearheads, Musicians, Coders, CEOs, Anarchists, Bikers, Historical Reenactors, Hipsters, and YOU!",
-		"civilopediaText": [{ "text": "E-NERGY ULTRA BRIGHT ZERO EMISSION STEALTH\n(Per 500ml Energy 11kCal(1%**)\nNiacin 43mg(266%**)\nPANTHOTENIC ACID 21mg (350%**)\nCaffeine-B 150mg (600%**)**%RDA)\nZERO SUGAR - JUST AS PUMPED!\nIn collaboration with Gearheads, Musicians, Coders, CEOs, Anarchists, Bikers, Historical Reenactors, Hipsters, and YOU!"}]
+		"civilopediaText": [{ "text": "E-NERGY ULTRA BRIGHT ZERO EMISSION STEALTH\n(Per 500ml Energy 11kCal(1%**)\nNiacin 43mg(266%**)\nPANTHOTENIC ACID 21mg (350%**)\nCaffeine-B 150mg (600%**)**%RDA)\nZERO SUGAR - JUST AS PUMPED!\nIn collaboration with Gearheads, Musicians, Coders, CEOs, Anarchists, Bikers, Historical Reenactors, Hipsters, and YOU!" }]
 	},
 	{
 		"name": "Produce Soft Drinks",
@@ -806,7 +806,7 @@
 			"Free [Modern Armor] appears"
 		],
 		"quote": "Oh, see the fire is sweepin, our very street today; burns like a red coat carpet, mad bull lost your way.. War, children! It's just a shot away!", // - Traditional nursery rhyme
-		"civilopediaText": [{ "text": "Oh, see the fire is sweepin, our very street today; burns like a red coat carpet, mad bull lost your way.. War, children! It's just a shot away!"}]
+		"civilopediaText": [{ "text": "Oh, see the fire is sweepin, our very street today; burns like a red coat carpet, mad bull lost your way.. War, children! It's just a shot away!" }]
 	},
 	{
 		"name": "Salvage Graveyard",
@@ -820,7 +820,7 @@
 			"Free [Patrol Boat] appears"
 		],
 		"quote": "He who commands the sea has command of everything.",
-		"civilopediaText": [{ "text": "He who commands the sea has command of everything."}]
+		"civilopediaText": [{ "text": "He who commands the sea has command of everything." }]
 	},
 	{
 		"name": "Turbine Hall",
@@ -831,7 +831,7 @@
 			"Provides [8] [Power]"
 		],
 		"quote": "At full capacity, these turbines were able to provide clean electricity for 31,052 homes, offsetting up to 51,997 tons of CO2 each year.", // - Promotional material
-		"civilopediaText": [{ "text": "At full capacity, these turbines were able to provide clean electricity for 31,052 homes, offsetting up to 51,997 tons of CO2 each year."}]
+		"civilopediaText": [{ "text": "At full capacity, these turbines were able to provide clean electricity for 31,052 homes, offsetting up to 51,997 tons of CO2 each year." }]
 	},
 	{
 		"name": "Secret Laboratory",
@@ -854,7 +854,7 @@
 			"Hidden when religion is disabled"
 		],
 		"quote": "And I seal up these records, after I have spoken a few words by way of exhortation unto you.",
-		"civilopediaText": [{ "text": "And I seal up these records, after I have spoken a few words by way of exhortation unto you."}]
+		"civilopediaText": [{ "text": "And I seal up these records, after I have spoken a few words by way of exhortation unto you." }]
 	},
 	{
 		"name": "Chemical Weapons Laboratory",
@@ -864,7 +864,7 @@
 		"greatPersonPoints": { "Great Scientist": 1 },
 		"uniques": [
 			"Must have an owned [Marsh] within [15] tiles",
-			"Requires [Supremacy]",
+			"Only available <after adopting [Supremacy]>",
 			"[Siege] units gain the [Chemical Weapons] promotion",
 			"[Air] units gain the [Chemical Weapons] promotion",
 			"[Helicopter] units gain the [Chemical Weapons] promotion",
@@ -2051,7 +2051,7 @@
 		"uniques": [
 			"Provides [1] [Electronics]",
 			"Consumes [1] [Power]",
-			"Requires [Monopoly]",
+			"Only available <after adopting [Monopoly]>",
 			"Only available <in cities with a [Factory]>"
 		],
 		"requiredTech": "Electronics"
@@ -2063,7 +2063,7 @@
 		"uniques": [
 			"Provides [1] [Machine Parts]",
 			"Consumes [1] [Power]",
-			"Requires [Monopoly]",
+			"Only available <after adopting [Monopoly]>",
 			"Only available <in cities with a [Factory]>"
 		],
 		"requiredTech": "Replaceable Parts"
@@ -2075,7 +2075,7 @@
 		"uniques": [
 			"[2] free [Tank] units appear",
 			"[+66]% Production when constructing [Armor] units [in this city]",
-			"Requires [Collectivism]",
+			"Only available <after adopting [Collectivism]>",
 			"Only available <in cities with a [Factory]>",
 			"Consumes [1] [Power]"
 		],
@@ -2280,7 +2280,7 @@
 			"[10]% Food is carried over after population increases [in this city]",
 			"[+25]% great person generation [in this city]",
 			"[-10]% unhappiness from population [in this city]",
-			"Requires [Arcology Project]",
+			"Only available <if [Arcology Project] is constructed>",
 			"Requires at least [2] population",
 			"Destroyed when the city is captured"
 		]
@@ -2290,7 +2290,7 @@
 		"cost": 1000,
 		"requiredTech": "Human Genome",
 		"uniques": [
-			"Requires [Cryo Project]",
+			"Only available <if [Cryo Project] is constructed>",
 			"Cannot be purchased",
 			"Only available <in cities with a [Medical Lab]>",
 			"Requires at least [5] population",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -5,6 +5,8 @@
 		"outerColor": [255, 255, 255]
 		// "innerColor": [255, 255, 255]
 	},
+
+	// Nations
 	{
 		"name": "Children of Rust",
 		"leaderName": "Scarlett",

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -7,7 +7,7 @@
 		"rangedStrength": 300,
 		"range": 8,
 		"cost": 1600,
-        "uniques": ["Requires [Faust Project]",
+        "uniques": ["Only available <if [Faust Project] is constructed>",
 			"Nuclear weapon of Strength [2]",
 			"Blast radius [2]",
 			"Unbuildable",
@@ -26,7 +26,7 @@
 		"requiredTech": "Gyroscopes",
 		"uniques": ["Nuclear weapon of Strength [1]",
 			"Blast radius [1]",
-			"Requires [Manhattan Project]",
+			"Only available <if [Manhattan Project] is constructed>",
 			"Consumes [1] [Uranium]"],
 		"hurryCostModifier": 20,
 		"attackSound": "nuke"
@@ -42,7 +42,7 @@
 		"requiredTech": "Rocketry",
 		"uniques": ["Nuclear weapon of Strength [2]",
 			"Blast radius [2]",
-			"Requires [Manhattan Project]",
+			"Only available <if [Manhattan Project] is constructed>",
 			"Consumes [1] [Uranium]"],
 		"hurryCostModifier": 20,
 		"attackSound": "nuke"
@@ -166,7 +166,7 @@
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Militia",
 		"uniques": ["Low Tech",
-			"Requires [Clubhouse]",
+			"Only available <if [Clubhouse] is constructed>",
 			"[+50]% Strength <vs [Mounted] units>"],
 		"promotions": ["Clansman"],
 		"attackSound": "metalhit"
@@ -251,7 +251,7 @@
 		"uniques": ["Low Tech",
 			"[+50]% Strength <vs cities>",
 			"[+50]% Strength <vs [Low Tech] units>",
-			"Requires [Forge]"],
+			"Only available <if [Forge] is constructed>"],
 		"attackSound": "metalhit"
 	},	
 	{
@@ -587,7 +587,7 @@
 		"upgradesTo": "NBC Infantry",
 		"hurryCostModifier": 20,		
 		"uniques": ["Personnel",
-			"Requires [Armory]",
+			"Only available <if [Armory] is constructed>",
 			"Consumes [1] [Weapons]"],
 		"promotions": ["Amphibious","Gas Mask"],
 		"attackSound": "machinegun"
@@ -603,7 +603,7 @@
 		"cost": 225,
 		"requiredTech": "Currency",	
 		"uniques": ["Personnel",
-			"Requires [Grand Clan Manor]",
+			"Only available <if [Grand Clan Manor] is constructed>",
 			"Consumes [1] [Weapons]"],
 		"promotions": ["Gas Mask","Reconnaissance I"],
 		"hurryCostModifier": 25,
@@ -619,7 +619,7 @@
 		"requiredTech": "Plastics",
 		"hurryCostModifier": 20,
 		"uniques": ["Personnel",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Weapons]"],
 		"promotions": ["Gas Mask"],
 		"attackSound": "machinegun"
@@ -635,7 +635,7 @@
 	//	"upgradesTo": "NBC Infantry", ??
 		"hurryCostModifier": 20,
 		"uniques": ["Personnel",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
 			"Only available <with [Slaves]>",
@@ -655,7 +655,7 @@
 		"requiredTech": "Plastics",
 		"hurryCostModifier": 20,
 		"uniques": ["Low Tech",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
 			"Only available <with [Slaves]>",
@@ -673,7 +673,7 @@
 		"requiredTech": "Future Materials",
 		"requiredResource": "Aluminum",
 		"hurryCostModifier": 50,
-		"uniques": ["Requires [Factory]"],
+		"uniques": ["Only available <if [Factory] is constructed>"],
 		"attackSound": "machinegun"
 	},*/
 	/*{
@@ -810,7 +810,7 @@
 		"hurryCostModifier": 20,
 		"requiredTech": "The Wheel",	
 		"uniques": ["Personnel",
-			"Requires [Armory]",
+			"Only available <if [Armory] is constructed>",
 			"Consumes [1] [Weapons]"],
 		"promotions": ["Reconnaissance I","Amphibious","Ambush","Gas Mask"],
 		"attackSound": "machinegun"
@@ -865,7 +865,7 @@
 		"requiredTech": "Plastics",		
 		"hurryCostModifier": 20,		
 		"uniques": ["Personnel",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Weapons]"],
 		"promotions": ["Reconnaissance I","Gas Mask"],
 		"attackSound": "shot"
@@ -880,7 +880,7 @@
 		"cost": 225,
 		"requiredTech": "Combined Arms",
 		"hurryCostModifier": 20,		
-		"uniques": ["Personnel","Requires [Factory]"],
+		"uniques": ["Personnel","Only available <if [Factory] is constructed>"],
 		"promotions": ["Reconnaissance I","Gas Mask","Extended Range"],
 		"attackSound": "shot"
 	},*/
@@ -902,7 +902,7 @@
 			"No defensive terrain bonus",
 			"Must set up to ranged attack",
 			"[-1] Sight",
-			"Requires [Blast Furnace]"],
+			"Only available <if [Blast Furnace] is constructed>"],
 		"attackSound": "cannon"
 	},
 	{
@@ -935,7 +935,7 @@
 		"requiredTech": "Munitions",
 		"upgradesTo": "Missile Vehicle",
 		"uniques": ["[+200]% Strength <vs [Armor] units>",
-			"Requires [Factory]"],
+			"Only available <if [Factory] is constructed>"],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
 	},
@@ -954,7 +954,7 @@
 			"[-50]% Strength <vs [Helicopter] units>",
 			"Must set up to ranged attack",
 			"[-1] Sight",
-			"Requires [Factory]"],
+			"Only available <if [Factory] is constructed>"],
 		"promotions": ["Artillery"],
 		"hurryCostModifier": 20,
 		"attackSound": "artillery"
@@ -971,7 +971,7 @@
 		"uniques": ["Must set up to ranged attack",
 			"[-33]% Strength <vs [Armor] units>",
 			"[-50]% Strength <vs cities>",
-			"Requires [Factory]"],
+			"Only available <if [Factory] is constructed>"],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
 	},
@@ -991,7 +991,7 @@
 			"[-33]% Strength <vs [Armor] units>",
 			"[-50]% Strength <vs cities>",
 			"Must set up to ranged attack",
-			"Requires [Factory]"],
+			"Only available <if [Factory] is constructed>"],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
 	},
@@ -1053,7 +1053,7 @@
 			"[-33]% Strength <vs cities>",
 			"Can move after attacking",
 			"No defensive terrain bonus",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
@@ -1070,7 +1070,7 @@
 		"requiredTech": "Iron Working",
 		"upgradesTo": "Tank",
 		"obsoleteTech": "Combined Arms",
-		"uniques": ["Requires [Chop Shop]",
+		"uniques": ["Only available <if [Chop Shop] is constructed>",
 			"[+50]% Strength <vs cities>",
 			"[+33]% Strength <vs [Ranged] units> <when defending>",
 			"Can move after attacking",
@@ -1091,7 +1091,7 @@
 		"requiredTech": "Engineering",
 		"upgradesTo": "Tank",
 		"obsoleteTech": "Combined Arms",
-		"uniques": ["Requires [Chop Shop]",
+		"uniques": ["Only available <if [Chop Shop] is constructed>",
 			"Can move after attacking",
 			"No defensive terrain bonus",
 			"Consumes [1] [Oil]"],
@@ -1136,7 +1136,7 @@
 		"uniques": ["Can move after attacking",
 			"[-25]% Strength <vs cities>",
 			"No defensive terrain bonus",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
@@ -1157,7 +1157,7 @@
 		"uniques": ["Can move after attacking",
 			"[-25]% Strength <vs cities>",
 			"No defensive terrain bonus",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
@@ -1176,7 +1176,7 @@
 			"[-50]% Strength <vs [Helicopter] units>",
 			"[-1] Sight",
 			"May withdraw before melee ([50]%)",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"promotions": ["Artillery"],
 		"hurryCostModifier": 20,
@@ -1195,7 +1195,7 @@
 			"No defensive terrain bonus",
 			"[+150]% Strength <vs [Armor] units>",
 			"May withdraw before melee ([75]%)",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "missile"
@@ -1215,7 +1215,7 @@
 			"[+300]% Strength <vs [Helicopter] units>",
 			"No defensive terrain bonus",
 			"May withdraw before melee ([50]%)",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "missile"
@@ -1234,7 +1234,7 @@
 		"uniques": ["Can move after attacking",
 			"[-25]% Strength <vs cities>",
 			"No defensive terrain bonus",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],		
 		"promotions": ["Point Defense Laser","Drone Recon"],
 		"hurryCostModifier": 20,
@@ -1256,7 +1256,7 @@
 			"Can move after attacking",
 			"[-25]% Strength <vs cities>",
 			"May withdraw before melee ([100]%)",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"promotions": ["Amphibious"],
 		"hurryCostModifier": 20,
@@ -1300,7 +1300,7 @@
 		"hurryCostModifier": 20,
 		"uniques": ["[100]% chance to intercept air attacks",
 			"[+100]% Strength <vs [Bomber] units>",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"attackSound": "machinegun"
 	},
@@ -1314,7 +1314,7 @@
 		"cost": 185,
 		"requiredTech": "Flight",
 		"upgradesTo": "Strike Drone",
-		"uniques": ["Requires [Factory]",
+		"uniques": ["Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"obsoleteTech": "Lasers",
 		"hurryCostModifier": 20,
@@ -1332,7 +1332,7 @@
 		"requiredTech": "Avionics",
 		"hurryCostModifier": 20,
 		"uniques": ["6 tiles in every direction always visible",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Only available <in cities with a [Factory]>",
 			"Consumes [1] [Aluminum]"],
 		"promotions": ["Automated"],
@@ -1350,7 +1350,7 @@
 		"hurryCostModifier": 20,
 		"uniques": ["[100]% chance to intercept air attacks",
 			"[+100]% Strength <vs [Bomber] units>",
-			"Requires [Aerospace Facility]",
+			"Only available <if [Aerospace Facility] is constructed>",
 			"Only available <in cities with a [Aerospace Facility]>",
 			"Consumes [1] [Oil]"],	
 		"attackSound": "jetgun"
@@ -1367,7 +1367,7 @@
 		"hurryCostModifier": 20,
 		"uniques": ["[100]% chance to intercept air attacks",
 			"[+100]% Strength <vs [Bomber] units>",
-			"Requires [Aerospace Facility]",
+			"Only available <if [Aerospace Facility] is constructed>",
 			"Only available <in cities with a [Aerospace Facility]>",
 			"Consumes [1] [Aluminum]"],
 		"promotions": ["Automated"],
@@ -1481,7 +1481,7 @@
 			"[+100]% Strength <vs [Air] units>",
 			"[+100]% Strength <vs [Helicopter] units>",
 			"May withdraw before melee ([66]%)",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "shipguns"
@@ -1496,7 +1496,7 @@
 		"cost": 400,
 		"requiredTech": "Radar",
         "uniques": ["Can carry [2] [Aircraft] units",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "shipguns"
@@ -1511,7 +1511,7 @@
 		"cost": 400,
 		"requiredTech": "Ballistics",
 		"uniques": ["[+25]% Strength <vs cities>",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"promotions": ["Artillery"],
 		"hurryCostModifier": 20,
@@ -1528,7 +1528,7 @@
 		"requiredTech": "Gyroscopes",
 		"uniques": ["[+66]% Strength <when attacking>",
 			"Can only attack [Water] tiles",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "torpedo"
@@ -1546,7 +1546,7 @@
 			"Can only attack [Water] tiles",
 			"[+1] Sight",
 			"Can carry [2] [Missile] units",
-			"Requires [Factory]",
+			"Only available <if [Factory] is constructed>",
 			"Consumes [1] [Uranium]"],
 		"attackSound": "torpedo"
 	},
@@ -1902,7 +1902,7 @@
 			"[-50]% Strength <vs [Helicopter] units>",
 			"Must set up to ranged attack",
 			"[-1] Sight",
-			"Requires [Factory]"],
+			"Only available <if [Factory] is constructed>"],
 		"promotions": ["Artillery"],
 		"hurryCostModifier": 20,
 		"attackSound": "artillery"
@@ -1919,7 +1919,7 @@
 		"upgradesTo": "Modern Armor",
 		"uniques": ["Can move after attacking",
 			"No defensive terrain bonus",
-			"Requires [Alma Tank Depot]",
+			"Only available <if [Alma Tank Depot] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"
@@ -1939,7 +1939,7 @@
 		"uniques": ["[-25]% Strength <vs [Armor] units>",
 			"Can move after attacking",
 			"May withdraw before melee ([100]%)",
-			"Requires [Alma Air Base]",
+			"Only available <if [Alma Air Base] is constructed>",
 			"Consumes [1] [Oil]"],
 		"promotions": ["Amphibious"],
 		"hurryCostModifier": 20,
@@ -1957,7 +1957,7 @@
 		"cost": 185,
 		"requiredTech": "The Wheel",
 		"upgradesTo": "Bomber",
-		"uniques": ["Requires [Alma Air Base]",
+		"uniques": ["Only available <if [Alma Air Base] is constructed>",
 			"Consumes [1] [Oil]"],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"


### PR DESCRIPTION
Addressing #23...

- Government buildings are now exclusively for capital
- Added Civilopedia entries for wonders with quotes
- `"Requires [buildingName]"` deprecated as of 3.19.12; Updated to `"Only available <if [buildingName] is constructed>"`