### PR TITLE
A few fixes and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DeCiv-Redux
-DeCiv Redux 4.0.0    
+DeCiv Redux 4.0.0
 12 December 2021
 
 DeCiv, made by [9kgsofrice](https://github.com/9kgsofrice/DeCiv/), brought back from the dead by SpacedOutChicken

--- a/jsons/Beliefs.json
+++ b/jsons/Beliefs.json
@@ -1,264 +1,330 @@
 [
-    {
-        "name": "Ancestor Worship",
-        "type": "Pantheon",
-        "uniques": ["[+1 Culture] from every [Shrine]"]
-    },
-    {
-        "name": "God of Winter",
-        "type": "Pantheon",
-        "uniques": ["[+1 Faith] from every [Tundra]", "[+1 Faith] from every [Snow]"]
-    },
-    {
-        "name": "Pray for Water",
-        "type": "Pantheon",
-        "uniques": ["[+1 Faith] from every [Desert]"]
-    },
-    {
-        "name": "Faith Healers",
-        "type": "Pantheon",
-        "uniques": ["[All] Units adjacent to this city heal [+30] HP per turn when healing"]
-        // This should be worded better
-    },
-    {
-        "name": "Fertility Rites",
-        "type": "Pantheon",
-        "uniques": ["[+10]% growth [in this city]"] 
-        // Preferably I would not have a cityFilter here, but doing so requires no additional implementation 
-    },
-    {
-        "name": "God of Labor",
-        "type": "Pantheon",
-        "uniques": ["[+1 Production] in cities with [3] or more population"]
-    },
-    {
-        "name": "God of Beasts",
-        "type": "Pantheon",
-        "uniques": ["[+1 Culture] from every [Pasture]"]
-    },
-    {
-        "name": "God of the Sea",
-        "type": "Pantheon",
-        "uniques": ["[+1 Production] from every [Fishing Boats]"]
-    },
-    {
-        "name": "Sacrificial Fire",
-        "type": "Pantheon",
-        "uniques": ["Earn [50]% of [Military] unit's [Strength] as [Faith] when killed within 4 tiles of a city following this religion"]
-    },
-    {
-        "name": "Lord of the Flies",
-        "type": "Pantheon",
-        "uniques": ["[+1 Culture, +1 Faith] from every [Insects]", "[+1 Culture, +1 Faith] from every [Hostile Fauna]"]
-    },
-    {
-        "name": "God of Love",
-        "type": "Pantheon",
-        "uniques": ["[+1 Happiness] in cities with [6] or more population"]
-    },
-    {
-        "name": "God of Walls",
-        "type": "Pantheon",
-        "uniques": ["[+30]% attacking Strength for cities"]
-    },
-    {
-        "name": "Lord of the Hunt",
-        "type": "Pantheon",
-        "uniques": ["[+1 Food] from every [Camp]"]
-    },
-    {
-        "name": "God of Commerce",
-        "type": "Pantheon",
-        "uniques": ["[+2 Science] from each Trade Route"]
-    },
-    {
-        "name": "Ancient Wonders",
-        "type": "Pantheon",
-        "uniques": ["[+4 Faith] from every [Natural Wonder]"]
-    },
-    {
-        "name": "Blessed Green",
-        "type": "Pantheon",
-        "uniques": ["[+1 Culture] from every [Tree plantation]", "[+1 Culture] from every [Farm]"]
-    },
-    {
-        "name": "Blessed Steel",
-        "type": "Pantheon",
-        "uniques": ["[+1 Culture, +1 Faith] from every [Metal]", "[+1 Culture, +1 Faith] from every [Silver]"]
-    },
-    {
-        "name": "Religious Settlements",
-        "type": "Pantheon",
-        "uniques": ["[-15]% Culture cost of natural border growth [in all cities]"]
-    },
-    {
-        "name": "Sacred Ruins",
-        "type": "Pantheon",
-        "uniques": ["[+1 Culture] from every [Jungle]", "[+1 Culture] from every [Forest]"]
-    },
-    {
-        "name": "Sacred Waters",
-        "type": "Pantheon",
-        "uniques": ["[+1 Happiness] in cities on [River] tiles"]
-    },
-    {
-        "name": "Strength of the Earth",
-        "type": "Pantheon",
-        "uniques": ["[+1 Faith] from every [Mine]"]
-    },
-///////////////////////////////////////// Follower beliefs /////////////////////////////////////////
-    
-    {
-        "name": "Hymns of Praise",
-        "type": "Follower",
-        "uniques": ["[+1 Happiness] from every [Shrine] <in cities where this religion has at least [3] followers>"]
-    },
-    {
-        "name": "Feed the Faithful",
-        "type": "Follower",
-        "uniques": ["[+1 Food] from every [Shrine]", "[+1 Food] from every [Monastery]"]
-    },
-    {
-        "name": "Obey the Elders",
-        "type": "Follower",
-        "uniques": ["[+2 Production] <if this city has at least [1] specialists>"]
-    },
-    {
-        "name": "Feast of Flesh",
-        "type": "Follower",
-        "uniques": ["[+2 Happiness] from every [Ranch]"]
-    },
-    {
-        "name": "Blessing of Peace",
-        "type": "Follower",
-        "uniques": ["[+15]% growth [in this city] <when not at war>"]
-    },
-    {
-        "name": "Art of War",
-        "type": "Follower",
-        "uniques": ["May buy [Military] units with [Faith] for [2] times their normal Production cost <before the [Industrial era]>"]
-    },
-    {
-        "name": "Pyramids",
-        "type": "Follower",
-        "uniques": ["May buy [Pyramid] buildings for [200] [Faith] [in cities following this religion]"]
-    },
-    {
-        "name": "Gardens",
-        "type": "Follower",
-        "uniques": ["May buy [Garden] buildings for [200] [Faith] [in cities following this religion]"]
-    },
-    {
-        "name": "Holy Fortresses",
-        "type": "Follower",
-        "uniques": ["May buy [Holy Fortress] buildings for [200] [Faith] [in cities following this religion]"]
-    },
-    {
-        "name": "Happiness in Faith",
-        "type": "Follower",
-        "uniques": ["[+2 Happiness] from every [Monastery] <in cities where this religion has at least [5] followers>"]
-    },
-    {
-        "name": "Labor of Love",
-        "type": "Follower",
-        "uniques": ["[+1]% [Production] from every follower, up to [15]%"]
-    },
+	// Pantheons
+	{
+		"name": "Ancestor Worship",
+		"type": "Pantheon",
+		"uniques": ["[+1 Culture] from every [Shrine]"]
+	},
+	{
+		"name": "God of Winter",
+		"type": "Pantheon",
+		"uniques": [
+			"[+1 Faith] from every [Tundra]",
+			"[+1 Faith] from every [Snow]"
+		]
+	},
+	{
+		"name": "Pray for Water",
+		"type": "Pantheon",
+		"uniques": ["[+1 Faith] from every [Desert]"]
+	},
+	{
+		"name": "Faith Healers",
+		"type": "Pantheon",
+		"uniques": [
+			// This should be worded better
+			"[All] Units adjacent to this city heal [+30] HP per turn when healing"
+		]
+	},
+	{
+		"name": "Fertility Rites",
+		"type": "Pantheon",
+		"uniques": [
+			// Preferably I would not have a cityFilter here
+			// but doing so requires no additional implementation
+			"[+10]% growth [in this city]"
+		]
+	},
+	{
+		"name": "God of Labor",
+		"type": "Pantheon",
+		"uniques": ["[+1 Production] in cities with [3] or more population"]
+	},
+	{
+		"name": "God of Beasts",
+		"type": "Pantheon",
+		"uniques": ["[+1 Culture] from every [Pasture]"]
+	},
+	{
+		"name": "God of the Sea",
+		"type": "Pantheon",
+		"uniques": ["[+1 Production] from every [Fishing Boats]"]
+	},
+	{
+		"name": "Sacrificial Fire",
+		"type": "Pantheon",
+		"uniques": [
+			"Earn [50]% of [Military] unit's [Strength] as [Faith] when killed within 4 tiles of a city following this religion"
+		]
+	},
+	{
+		"name": "Lord of the Flies",
+		"type": "Pantheon",
+		"uniques": [
+			"[+1 Culture, +1 Faith] from every [Insects]",
+			"[+1 Culture, +1 Faith] from every [Hostile Fauna]"
+		]
+	},
+	{
+		"name": "God of Love",
+		"type": "Pantheon",
+		"uniques": ["[+1 Happiness] in cities with [6] or more population"]
+	},
+	{
+		"name": "God of Walls",
+		"type": "Pantheon",
+		"uniques": ["[+30]% attacking Strength for cities"]
+	},
+	{
+		"name": "Lord of the Hunt",
+		"type": "Pantheon",
+		"uniques": ["[+1 Food] from every [Camp]"]
+	},
+	{
+		"name": "God of Commerce",
+		"type": "Pantheon",
+		"uniques": ["[+2 Science] from each Trade Route"]
+	},
+	{
+		"name": "Ancient Wonders",
+		"type": "Pantheon",
+		"uniques": ["[+4 Faith] from every [Natural Wonder]"]
+	},
+	{
+		"name": "Blessed Green",
+		"type": "Pantheon",
+		"uniques": [
+			"[+1 Culture] from every [Tree plantation]",
+			"[+1 Culture] from every [Farm]"
+		]
+	},
+	{
+		"name": "Blessed Steel",
+		"type": "Pantheon",
+		"uniques": [
+			"[+1 Culture, +1 Faith] from every [Metal]",
+			"[+1 Culture, +1 Faith] from every [Silver]"
+		]
+	},
+	{
+		"name": "Religious Settlements",
+		"type": "Pantheon",
+		"uniques": [
+			"[-15]% Culture cost of natural border growth [in all cities]"
+		]
+	},
+	{
+		"name": "Sacred Ruins",
+		"type": "Pantheon",
+		"uniques": [
+			"[+1 Culture] from every [Jungle]",
+			"[+1 Culture] from every [Forest]"
+		]
+	},
+	{
+		"name": "Sacred Waters",
+		"type": "Pantheon",
+		"uniques": ["[+1 Happiness] in cities on [River] tiles"]
+	},
+	{
+		"name": "Strength of the Earth",
+		"type": "Pantheon",
+		"uniques": ["[+1 Faith] from every [Mine]"]
+	},
 
-    ///////////////////////////////////////// Founder beliefs //////////////////////////////////////////
-    
-    {
-        "name": "Ceremonial Burial",
-        "type": "Founder",
-        "uniques": ["[+1 Happiness] for each global city following this religion"]
-    },
-    {
-        "name": "Church Property",
-        "type": "Founder",
-        "uniques": ["[+2 Gold] for each global city following this religion"]
-    },
-    {
-        "name": "Initiation Rites",
-        "type": "Founder",
-        "uniques": ["[+100 Gold] when a city adopts this religion for the first time (modified by game speed)"]
-    },
-    {
-        "name": "Interfaith Dialogue",
-        "type": "Founder",
-        "uniques": ["When spreading religion to a city, gain [10] times the amount of followers of other religions as [Science]"]
-    },
-    {
-        "name": "Primacy",
-        "type": "Founder",
-        "uniques": ["Resting point for Influence with City-States following this religion [+15]"]
-    },
-    {
-        "name": "Peace Loving",
-        "type": "Founder",
-        "uniques": ["[+1 Happiness] for every [5] global followers [in non-enemy foreign cities]"]
-    },
-    {
-        "name": "Pilgrimage",
-        "type": "Founder",
-        "uniques": ["[+2 Faith] for each global city following this religion"]
-    },
-    {
-        "name": "Tithe",
-        "type": "Founder",
-        "uniques": ["[+1 Gold] for every [4] global followers [in all cities]"]
-    },
-    {
-        "name": "World Church",
-        "type": "Founder",
-        "uniques": ["[+1 Culture] for every [5] global followers [in foreign cities]"]
-    },
+	// Follower beliefs
+	{
+		"name": "Hymns of Praise",
+		"type": "Follower",
+		"uniques": [
+			"[+1 Happiness] from every [Shrine] <in cities where this religion has at least [3] followers>"
+		]
+	},
+	{
+		"name": "Feed the Faithful",
+		"type": "Follower",
+		"uniques": [
+			"[+1 Food] from every [Shrine]",
+			"[+1 Food] from every [Monastery]"
+		]
+	},
+	{
+		"name": "Obey the Elders",
+		"type": "Follower",
+		"uniques": [
+			"[+2 Production] <if this city has at least [1] specialists>"
+		]
+	},
+	{
+		"name": "Feast of Flesh",
+		"type": "Follower",
+		"uniques": ["[+2 Happiness] from every [Ranch]"]
+	},
+	{
+		"name": "Blessing of Peace",
+		"type": "Follower",
+		"uniques": ["[+15]% growth [in this city] <when not at war>"]
+	},
+	{
+		"name": "Art of War",
+		"type": "Follower",
+		"uniques": [
+			"May buy [Military] units with [Faith] for [2] times their normal Production cost <before the [Industrial era]>"
+		]
+	},
+	{
+		"name": "Pyramids",
+		"type": "Follower",
+		"uniques": [
+			"May buy [Pyramid] buildings for [200] [Faith] [in cities following this religion]"
+		]
+	},
+	{
+		"name": "Gardens",
+		"type": "Follower",
+		"uniques": [
+			"May buy [Garden] buildings for [200] [Faith] [in cities following this religion]"
+		]
+	},
+	{
+		"name": "Holy Fortresses",
+		"type": "Follower",
+		"uniques": [
+			"May buy [Holy Fortress] buildings for [200] [Faith] [in cities following this religion]"
+		]
+	},
+	{
+		"name": "Happiness in Faith",
+		"type": "Follower",
+		"uniques": [
+			"[+2 Happiness] from every [Monastery] <in cities where this religion has at least [5] followers>"
+		]
+	},
+	{
+		"name": "Labor of Love",
+		"type": "Follower",
+		"uniques": ["[+1]% [Production] from every follower, up to [15]%"]
+	},
 
-    ////////////////////////////////////// Enhancer beliefs ///////////////////////////////////////
+	// Founder beliefs
+	{
+		"name": "Ceremonial Burial",
+		"type": "Founder",
+		"uniques": [
+			"[+1 Happiness] for each global city following this religion"
+		]
+	},
+	{
+		"name": "Church Property",
+		"type": "Founder",
+		"uniques": ["[+2 Gold] for each global city following this religion"]
+	},
+	{
+		"name": "Initiation Rites",
+		"type": "Founder",
+		"uniques": [
+			"[+100 Gold] when a city adopts this religion for the first time (modified by game speed)"
+		]
+	},
+	{
+		"name": "Interfaith Dialogue",
+		"type": "Founder",
+		"uniques": [
+			"When spreading religion to a city, gain [10] times the amount of followers of other religions as [Science]"
+		]
+	},
+	{
+		"name": "Primacy",
+		"type": "Founder",
+		"uniques": [
+			"Resting point for Influence with City-States following this religion [+15]"
+		]
+	},
+	{
+		"name": "Peace Loving",
+		"type": "Founder",
+		"uniques": [
+			"[+1 Happiness] for every [5] global followers [in non-enemy foreign cities]"
+		]
+	},
+	{
+		"name": "Pilgrimage",
+		"type": "Founder",
+		"uniques": ["[+2 Faith] for each global city following this religion"]
+	},
+	{
+		"name": "Tithe",
+		"type": "Founder",
+		"uniques": ["[+1 Gold] for every [4] global followers [in all cities]"]
+	},
+	{
+		"name": "World Church",
+		"type": "Founder",
+		"uniques": [
+			"[+1 Culture] for every [5] global followers [in foreign cities]"
+		]
+	},
 
-    {
-        "name": "Defender of the Faith",
-        "type": "Enhancer",
-        "uniques": ["[+20]% Strength <for [All] units> <when fighting in [Friendly Land] tiles>"]
-        // ToDo: Should only be friendly territory of cities that follow this religion
-    },
-    {
-        "name": "Illuminated Order",
-        "type": "Enhancer",
-        "uniques": ["[Faith] cost of purchasing [Philosopher] units [-30]%", "[Faith] cost of purchasing [Censor] units [-30]%"]
-    },
-    {
-        "name": "Itinerant Preachers",
-        "type": "Enhancer",
-        "uniques": ["Religion naturally spreads to cities [+3] tiles away"]
-    },
-    {
-        "name": "Just War",
-        "type": "Enhancer",
-        "uniques": ["[+20]% Strength <for [All] units> <when fighting in [Enemy Land] tiles>"]
-        // ToDo: Should only be enemy territory of cities that follow this religion
-    },
-    {
-        "name": "Path of the Sage",
-        "type": "Enhancer",
-        "uniques": ["[+25]% Spread Religion Strength <for [Great Sage] units>", "[-25]% Faith cost of generating Great Prophet equivalents", "[Faith] cost for [Great Sage] units [-25]%"]
-    },
-    {
-        "name": "Missionary Zeal",
-        "type": "Enhancer",
-        "uniques": ["[+25]% Spread Religion Strength <for [Philosopher] units>"]
-    },
-    {
-        "name": "Religious Texts",
-        "type": "Enhancer",
-        "uniques": ["[+34]% Natural religion spread [in all cities]", "[+34]% Natural religion spread [in all cities] <after discovering [Education]>"]
-    },
-    {
-        "name": "Religious Unity",
-        "type": "Enhancer",
-        "uniques": ["[+100]% Natural religion spread [in City-State cities]"]
-    },
-    {
-        "name": "Funeral Rites",
-        "type": "Enhancer",
-        "uniques": ["[+50 Faith] whenever a Great Person is expended"]
-    }
+	// Enhancer beliefs
+	{
+		"name": "Defender of the Faith",
+		"type": "Enhancer",
+		"uniques": [
+			// TODO: Should only be friendly territory of cities that follow this religion
+			"[+20]% Strength <for [All] units> <when fighting in [Friendly Land] tiles>"
+		]
+	},
+	{
+		"name": "Illuminated Order",
+		"type": "Enhancer",
+		"uniques": [
+			"[Faith] cost of purchasing [Philosopher] units [-30]%",
+			"[Faith] cost of purchasing [Censor] units [-30]%"
+		]
+	},
+	{
+		"name": "Itinerant Preachers",
+		"type": "Enhancer",
+		"uniques": ["Religion naturally spreads to cities [+3] tiles away"]
+	},
+	{
+		"name": "Just War",
+		"type": "Enhancer",
+		"uniques": [
+			// TODO: Should only be enemy territory of cities that follow this religion
+			"[+20]% Strength <for [All] units> <when fighting in [Enemy Land] tiles>"
+		]
+	},
+	{
+		"name": "Path of the Sage",
+		"type": "Enhancer",
+		"uniques": [
+			"[+25]% Spread Religion Strength <for [Great Sage] units>",
+			"[-25]% Faith cost of generating Great Prophet equivalents",
+			"[Faith] cost for [Great Sage] units [-25]%"
+		]
+	},
+	{
+		"name": "Missionary Zeal",
+		"type": "Enhancer",
+		"uniques": ["[+25]% Spread Religion Strength <for [Philosopher] units>"]
+	},
+	{
+		"name": "Religious Texts",
+		"type": "Enhancer",
+		"uniques": [
+			"[+34]% Natural religion spread [in all cities]",
+			"[+34]% Natural religion spread [in all cities] <after discovering [Education]>"
+		]
+	},
+	{
+		"name": "Religious Unity",
+		"type": "Enhancer",
+		"uniques": ["[+100]% Natural religion spread [in City-State cities]"]
+	},
+	{
+		"name": "Funeral Rites",
+		"type": "Enhancer",
+		"uniques": ["[+50 Faith] whenever a Great Person is expended"]
+	}
 ]

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -560,8 +560,8 @@
 		"style": "Tribal",
 		"uniqueName": "People of the Sea",
 		"uniques": [
-			"Enables embarkation for land units <starting from the [Decivilized era]>",
-			"Enables [All] units to enter ocean tiles <starting from the [Decivilized era]>",
+			"Enables embarkation for land units",
+			"Enables [All] units to enter ocean tiles",
 			"Units pay only 1 movement point to disembark",
 			"Defense bonus when embarked <for [All] units>",
 			"[{Land} {Low Tech}] units gain the [Amphibious] promotion",

--- a/jsons/Techs.json
+++ b/jsons/Techs.json
@@ -105,7 +105,7 @@
 				"prerequisites": ["Writing", "Sailing"],
 				"uniques": [
 					"[+1] Movement <for [Embarked] units>",
-					"Enables embarked units to enter ocean tiles"
+					"Enables [Embarked] units to enter ocean tiles"
 				],
 				"quote": "He made an instrument to know if the moon shine at full or no."
 			},

--- a/jsons/Techs.json
+++ b/jsons/Techs.json
@@ -7,27 +7,27 @@
 		"wonderCost": 100,
 		"techs": [
 			{
-			//Survivalism  - salvage, weapons, make farm
+				//Survivalism  - salvage, weapons, make farm
 				"name": "The Wheel",
 				"row": 5,
 				"quote": "",
 				"uniques": ["Starting tech"]
 			}
-		]	
+		]
 	},
 	{
 		"columnNumber": 1,
 		"era": "Decivilized era",
-		"techCost": 60, 
+		"techCost": 60,
 		"buildingCost": 60,
 		"wonderCost": 125,
-		"techs": [			
+		"techs": [
 			{
 				"name": "Sailing",
 				"row": 1,
 				"prerequisites": ["The Wheel"],
 				"uniques": ["Enables embarkation for land units"],
-				"quote": "He who commands the sea has command of everything."		
+				"quote": "He who commands the sea has command of everything."
 			},
 			{
 				"name": "Redomestication",
@@ -47,23 +47,23 @@
 				"row": 7,
 				"prerequisites": ["The Wheel"],
 				"quote": "I know not with what weapons World War III will be fought, but World War IV will be fought with sticks and stones."
-			},			
+			},
 			{
 				"name": "Construction",
 				"row": 9,
 				"prerequisites": ["The Wheel"],
 				"quote": "How happy are those whose walls already rise!"
 			}
-		]	
+		]
 	},
 	{
-	// level 2 - 
+		// level 2 -
 		"columnNumber": 2,
 		"era": "Decivilized era",
-		"techCost": 120, 
+		"techCost": 120,
 		"buildingCost": 75,
 		"wonderCost": 185,
-		"techs": [	
+		"techs": [
 			{
 				"name": "Writing",
 				"row": 5,
@@ -82,7 +82,7 @@
 				"row": 9,
 				"prerequisites": ["Construction"],
 				"quote": "The meek shall inherit the Earth, but not its mineral rights."
-			},				
+			},
 			{
 				"name": "Trade",
 				"row": 10,
@@ -90,55 +90,56 @@
 				"uniques": ["Enables Open Borders agreements"],
 				"quote": "I know that all of us here have earned our places beyond doubt. But we are not safe, even here, and we cannot afford to stand still. I need your support today. I was appointed to this position not to sit behind a desk, but to fix problems, and that is what I intend to do..."
 			}
-		]	
+		]
 	},
 	{
 		"columnNumber": 3,
 		"era": "Rediscovering era",
-		"techCost": 250, 
+		"techCost": 250,
 		"buildingCost": 100,
 		"wonderCost": 250,
 		"techs": [
 			{
 				"name": "Astronomy",
 				"row": 1,
-				"prerequisites": ["Writing","Sailing"],
-				"uniques": ["[+1] Movement <for [Embarked] units>","Enables embarked units to enter ocean tiles"],
+				"prerequisites": ["Writing", "Sailing"],
+				"uniques": [
+					"[+1] Movement <for [Embarked] units>",
+					"Enables embarked units to enter ocean tiles"
+				],
 				"quote": "He made an instrument to know if the moon shine at full or no."
 			},
 			{
 				"name": "Botany",
 				"row": 3,
-				"prerequisites": ["Redomestication","Writing"],
+				"prerequisites": ["Redomestication", "Writing"],
 				"quote": "Be at peace in the knowledge that all the neoliberals will die with the biosphere."
 			},
-			
+
 			{
 				"name": "Chemistry",
 				"row": 6,
 				"prerequisites": ["Writing"],
 				"quote": "For the days of my life have vanished like smoke, and my bones are grown dry like fuel for the fire.",
 				"uniques": ["Enables conversion of city production to gold"]
-				},
-
+			},
 
 			{
 				"name": "Engineering",
 				"row": 8,
-				"prerequisites": ["Mining","Machinery"],
+				"prerequisites": ["Mining", "Machinery"],
 				"uniques": ["Roads connect tiles across rivers"],
 				"quote": "History doesn't repeat itself but it often rhymes."
-			}	
-		]	
+			}
+		]
 	},
 	{
 		"columnNumber": 4,
 		"era": "Rediscovering era",
-		"techCost": 425, 
+		"techCost": 425,
 		"buildingCost": 120,
 		"wonderCost": 300,
 		"techs": [
-		
 			{
 				"name": "Education",
 				"row": 4,
@@ -150,16 +151,16 @@
 			{
 				"name": "Steel",
 				"row": 8,
-				"prerequisites": ["Chemistry","Engineering"],
+				"prerequisites": ["Chemistry", "Engineering"],
 				"quote": "The old men are all dead. It is the young men who say yes or no."
 			},
 			{
 				"name": "Currency",
 				"row": 10,
-				"prerequisites": ["Chemistry","Trade","Engineering"],
+				"prerequisites": ["Chemistry", "Trade", "Engineering"],
 				"quote": "The ancient emporer Covfefe had such a fortune of pure water, he would wash his toilet with it."
 			}
-		]	
+		]
 	},
 	{
 		"columnNumber": 5,
@@ -168,45 +169,41 @@
 		"buildingCost": 160,
 		"wonderCost": 400,
 		"techs": [
-					
 			{
 				"name": "Ecology",
 				"row": 3,
-				"prerequisites": ["Education","Botany"],
+				"prerequisites": ["Education", "Botany"],
 				"quote": "Modern industrial farming is largely a strategy for turning fossil fuels into food."
-			},		
+			},
 			{
 				"name": "Biology",
 				"row": 5,
-				"prerequisites": ["Chemistry","Education"],
+				"prerequisites": ["Chemistry", "Education"],
 				"uniques": ["[+10]% growth [in all cities]"],
 				"quote": "If the brain were so simple we could understand it, we would be so simple we couldn't."
-			},				
+			},
 			{
-				"name": "Steam Power",//steam power
+				"name": "Steam Power", //steam power
 				"row": 7,
 				"prerequisites": ["Steel"],
 				"uniques": ["[+1] Movement <for [Embarked] units>"],
 				"quote": "Is it a fact - or have I dreamt it - that, by means of electricity, the world of matter has become a great nerve, vibrating thousands of miles in a breathless point of time?"
-			},			
+			},
 			{
 				"name": "Civil Service",
 				"row": 10,
 				"prerequisites": ["Currency"],
 				"quote": "They are casting their problems on society. And, you know, there is no such thing as society."
 			}
-			
 		]
 	},
 	{
 		"columnNumber": 6,
 		"era": "Neofeudal era",
-		"techCost": 1000, 
+		"techCost": 1000,
 		"buildingCost": 200,
 		"wonderCost": 500,
 		"techs": [
-					
-
 			{
 				"name": "Decontamination",
 				"row": 3,
@@ -216,16 +213,16 @@
 			{
 				"name": "Refrigeration",
 				"row": 5,
-				"prerequisites": ["Biology","Steam Power"],
+				"prerequisites": ["Biology", "Steam Power"],
 				"quote": "And homeless near a thousand homes I stood, and near a thousand tables pined and wanted food."
 			},
-					
+
 			{
 				"name": "Manufacturing",
 				"row": 7,
 				"prerequisites": ["Steam Power"],
 				"quote": "Manufacturing based on machinery, already referred to as a characteristic of our age, is but one aspect of the revolution that is being wrought by technology."
-			},				
+			},
 			{
 				"name": "Rifling",
 				"row": 8,
@@ -235,33 +232,32 @@
 			{
 				"name": "Radio",
 				"row": 10,
-				"prerequisites": ["Civil Service","Steam Power"],
+				"prerequisites": ["Civil Service", "Steam Power"],
 				"quote": "Has the last word been said? Must hope disappear? Is defeat final? No! Believe me, I speak to you with full knowledge of the facts and tell you that nothing is lost."
 			}
-
-		]	
+		]
 	},
 	{
 		"columnNumber": 7,
 		"era": "Rebuilding era",
-		"techCost": 1300, 
+		"techCost": 1300,
 		"buildingCost": 250,
 		"wonderCost": 625,
-		"techs": [	
+		"techs": [
 			{
 				"name": "Desalination",
 				"row": 1,
-				"prerequisites": ["Decontamination","Astronomy"],
+				"prerequisites": ["Decontamination", "Astronomy"],
 				"quote": "Record the start and finish times of the lights and appliances when you are finished in your logbook. If your role involves access to running water, you must record the meter readings before and after use. Failure to do so will lead to disciplinary action.\n\nRemember -\nEVERY DROP COSTS"
 			},
-			{			
+			{
 				"name": "Laboratory",
 				"row": 3,
 				"uniques": ["Enables conversion of city production to science"],
-				"prerequisites": ["Decontamination","Refrigeration"],
+				"prerequisites": ["Decontamination", "Refrigeration"],
 				"quote": "There is a plague on Man: his opinion that he knows something."
 			},
-		
+
 			{
 				"name": "Electronics",
 				"row": 5,
@@ -271,32 +267,30 @@
 			{
 				"name": "Replaceable Parts",
 				"row": 7,
-				"prerequisites": ["Manufacturing","Rifling"],
+				"prerequisites": ["Manufacturing", "Rifling"],
 				"quote": "Nothing is particularly hard if you divide it into small jobs."
-			},			
+			},
 			{
 				"name": "Munitions",
 				"row": 8,
 				"prerequisites": ["Rifling"],
 				"quote": "As soon as men decide that all means are permitted to fight an evil, then their good becomes indistinguishable from the evil that they set out to destroy."
-			},	
+			},
 			{
 				"name": "Railroads",
 				"row": 9,
 				"prerequisites": ["Manufacturing"],
 				"quote": "Iron and heat are, as we know, the supporters, the bases, of the mechanic arts."
 			}
-			
-		]	
+		]
 	},
 	{
 		"columnNumber": 8,
 		"era": "Rebuilding era",
-		"techCost": 2000, 
+		"techCost": 2000,
 		"buildingCost": 300,
 		"wonderCost": 750,
 		"techs": [
-
 			{
 				"name": "Hydroponics",
 				"row": 2,
@@ -306,23 +300,22 @@
 			{
 				"name": "Plastics",
 				"row": 5,
-				"prerequisites": ["Replaceable Parts","Laboratory"],
+				"prerequisites": ["Replaceable Parts", "Laboratory"],
 				"quote": "Ben, I want to say one word to you, just one word: plastics."
-			},				
+			},
 			{
 				"name": "Flight",
 				"row": 7,
-				"prerequisites": ["Electronics","Replaceable Parts"],
+				"prerequisites": ["Electronics", "Replaceable Parts"],
 				"quote": "Aeronautics was neither an industry nor a science. It was a miracle."
-			},				
+			},
 			{
 				"name": "Ballistics",
 				"row": 8,
-				"prerequisites": ["Munitions","Replaceable Parts"],
+				"prerequisites": ["Munitions", "Replaceable Parts"],
 				"quote": "Our goal is not the victory of might, but the vindication of right; not peace at the expense of freedom, but both peace and freedom, here in this hemisphere, and, we hope, around the world.\n\nGod willing, that goal will be achieved."
 			}
-
-		]	
+		]
 	},
 	{
 		"columnNumber": 9,
@@ -338,24 +331,27 @@
 				"quote": "The nation that destroys its soil destroys itself."
 			},
 			{
-				"name": "Computers", 
+				"name": "Computers",
 				"row": 4,
 				"prerequisites": ["Plastics"],
-				"uniques": ["[+10]% [Science] [in all cities]","[+10]% [Production] [in all cities]"],
+				"uniques": [
+					"[+10]% [Science] [in all cities]",
+					"[+10]% [Production] [in all cities]"
+				],
 				"quote": "This has been a challenging quarter with falls in demand from states and agencies. Blackwarden Associates has recalibrated its operations across geographies, moving away from security and relief operations in Asia and divesting from the radiological remediation sector. By focusing on core domestic operations for private sector clients, we have successfully generated free cashflows despite adverse market conditions."
-			},				
+			},
 
 			{
 				"name": "Gyroscopes",
 				"row": 7,
-				"prerequisites": ["Flight","Ballistics"],
+				"prerequisites": ["Flight", "Ballistics"],
 				"quote": "Things may be the same again; and we must fight\nNot in the hope of winning but rather of keeping\nSomething alive: so that when we meet our end,\nIt may be said that we tackled wherever we could,\nThat battle-fit we lived, and though defeated,\nNot without glory fought."
 			},
-		
+
 			{
 				"name": "Combined Arms",
 				"row": 8,
-				"prerequisites": ["Ballistics","Railroads"],
+				"prerequisites": ["Ballistics", "Railroads"],
 				"quote": "The root of the evil is not the construction of new, more dreadful weapons. It is the spirit of conquest."
 			},
 			{
@@ -364,7 +360,7 @@
 				"prerequisites": ["Radio"],
 				"quote": "Vision is the art of seeing things invisible."
 			}
-		]	
+		]
 	},
 	{
 		"columnNumber": 10,
@@ -373,23 +369,19 @@
 		"buildingCost": 500,
 		"wonderCost": 1060,
 		"techs": [
-
 			{
 				"name": "Networking",
 				"row": 4,
 				"prerequisites": ["Computers"],
-				"quote": "In a real sense, the empires of old collapsed under their own weight; vast hierarchies of bureacrats, functionaries with no function, leaders without legitimacy. They could not adapt, not even to save themselves. From their ashes, we are building a new State; lean, strong, and vital."//
-			},	
+				"quote": "In a real sense, the empires of old collapsed under their own weight; vast hierarchies of bureacrats, functionaries with no function, leaders without legitimacy. They could not adapt, not even to save themselves. From their ashes, we are building a new State; lean, strong, and vital." //
+			},
 			{
 				"name": "Avionics",
 				"row": 6,
-				"prerequisites": ["Radar","Gyroscopes","Computers"],
+				"prerequisites": ["Radar", "Gyroscopes", "Computers"],
 				"quote": "In the end, that’s what this election is about. Do we participate in a politics of cynicism, or do we participate in a politics of hope?"
 			}
-			
-
-
-		]	
+		]
 	},
 	{
 		"columnNumber": 11,
@@ -401,7 +393,7 @@
 			{
 				"name": "Ocean Remediation",
 				"row": 1,
-				"prerequisites": ["Desalination","Land Remediation"],
+				"prerequisites": ["Desalination", "Land Remediation"],
 				"quote": "Only within the moment of time represented by the present century has one species, man, acquired significant power to alter the nature of his world."
 			},
 			{
@@ -415,14 +407,14 @@
 				"row": 7,
 				"prerequisites": ["Gyroscopes"],
 				"quote": "A good rule for rocket experimenters to follow is this: always assume that it will explode."
-			},	
+			},
 			{
 				"name": "Social Engineering",
 				"row": 10,
-				"prerequisites": ["Radar","Networking"],
+				"prerequisites": ["Radar", "Networking"],
 				"quote": "Anyone who believes exponential growth can go on forever in a finite world is either a madman or an economist."
 			}
-		]	
+		]
 	},
 	{
 		"columnNumber": 12,
@@ -436,7 +428,7 @@
 				"row": 2,
 				"prerequisites": ["Decryption"],
 				"quote": "Each of the original messages contains a silver of wisdom, and whenever they seem to say different or incompatible things it is only because all are alluding, allegorically, to the same primeval truth.\n \nAs a consequence, there can be no advancement of learning. Truth has been already spelled out once and for all, and we can only keep interpreting its obscure message..."
-			},		
+			},
 			{
 				"name": "Pharmaceuticals",
 				"row": 3,
@@ -452,20 +444,17 @@
 			{
 				"name": "Lasers",
 				"row": 6,
-				"prerequisites": ["Avionics","Rocketry","Decryption"],
+				"prerequisites": ["Avionics", "Rocketry", "Decryption"],
 				"quote": "The night is far spent, the day is at hand: let us therefore cast off the works of darkness, and let us put on the armor of light."
-			},	
-		
+			},
+
 			{
 				"name": "Satellites",
 				"row": 7,
 				"prerequisites": ["Rocketry"],
 				"quote": ""
 			}
-			
-
-
-		]	
+		]
 	},
 	{
 		"columnNumber": 13,
@@ -477,9 +466,9 @@
 			{
 				"name": "Human Genome",
 				"row": 2,
-				"prerequisites": ["Genetics","Pharmaceuticals"],
+				"prerequisites": ["Genetics", "Pharmaceuticals"],
 				"quote": "Humanity should study the foundations of heredity. But this will be possible only when science is liberated from superstition and limitation."
-			},	
+			},
 			{
 				"name": "Plastics Recycling",
 				"row": 3,
@@ -498,7 +487,7 @@
 				"prerequisites": ["Social Engineering", "Satellites"],
 				"quote": "This is where we are tonight, everybody under surveillance by a satellite\nYou can be the first one on your block to die"
 			}
-		]	
+		]
 	},
 	{
 		"columnNumber": 14,
@@ -507,30 +496,24 @@
 		"buildingCost": 750,
 		"wonderCost": 2000,
 		"techs": [
-
-
 			{
 				"name": "Particle Physics",
 				"row": 4,
-				"prerequisites": ["Lasers","Nuclear Fission"],
+				"prerequisites": ["Lasers", "Nuclear Fission"],
 				"quote": "Every particle of matter is attracted by or gravitates to every other particle of matter with a force inversely proportional to the squares of their distances."
-			},			
+			},
 			{
 				"name": "Energy Weapons",
 				"row": 6,
-				"prerequisites": ["Lasers","Advanced Materials"],
+				"prerequisites": ["Lasers", "Advanced Materials"],
 				"quote": "I believe that man will not merely endure: he will prevail. He is immortal, not because he alone among creatures has an inexhaustible voice, but because he has a soul, a spirit capable of compassion and sacrifice and endurance."
 			},
 			{
 				"name": "Robotics",
 				"row": 7,
-				"prerequisites": ["Lasers","Satellites"],
+				"prerequisites": ["Lasers", "Satellites"],
 				"quote": "1. A robot may not injure a human being or, through inaction, allow a human being to come to harm. 2. A robot must obey any orders given to it by human beings, except when such orders would conflict with the First Law. 3. A robot must protect its own existence as long as such protection does not conflict with the First or Second Law."
 			}
-
-
-
-
 		]
 	},
 	{
@@ -540,14 +523,13 @@
 		"buildingCost": 750,
 		"wonderCost": 2000,
 		"techs": [
-	
 			{
 				"name": "Atmosphere Remediation",
 				"row": 1,
-				"prerequisites": ["Plastics Recycling","Ocean Remediation"],
+				"prerequisites": ["Plastics Recycling", "Ocean Remediation"],
 				"quote": "All analysed pathways limiting warming to 1.5°C with no or limited overshoot use CO2 removal to some extent to neutralize emissions."
-			},	
-		
+			},
+
 			/*{
 				"name": "Nanotechnology",
 				"row": 5,
@@ -567,9 +549,9 @@
 				"prerequisites": ["Advanced Materials"],
 				"quote": "You ask, what is our aim? I can answer in one word. It is victory. Victory at all costs - Victory in spite of all terrors - Victory, however long and hard the road may be, for without victory there is no survival."
 			}
-		]	
+		]
 	},
-	
+
 	{
 		"columnNumber": 16,
 		"era": "New Future era",
@@ -586,7 +568,7 @@
 			{
 				"name": "Future Power",
 				"row": 4,
-				"prerequisites": ["Particle Physics","Energy Weapons"],
+				"prerequisites": ["Particle Physics", "Energy Weapons"],
 				"quote": "All the towers of ivory are crumbling, and the swallows have sharpened their beaks..."
 			},
 			{
@@ -595,7 +577,6 @@
 				"prerequisites": ["Incentivization"],
 				"quote": "The new electronic interdependence recreates the world in the image of a global village."
 			}
-
 		]
 	},
 	{
@@ -608,10 +589,20 @@
 			{
 				"name": "Future Tech",
 				"row": 5,
-				"prerequisites": ["Geo Engineering","Future Power","Artificial Intelligence","Future Materials","Human Genome","Globalization"],
-				"uniques": ["Who knows what the future holds?", "Can be continually researched"],
+				"prerequisites": [
+					"Geo Engineering",
+					"Future Power",
+					"Artificial Intelligence",
+					"Future Materials",
+					"Human Genome",
+					"Globalization"
+				],
+				"uniques": [
+					"Who knows what the future holds?",
+					"Can be continually researched"
+				],
 				"quote": "I think we agree, the past is over."
 			}
-		]	
+		]
 	}
 ]

--- a/jsons/Terrains.json
+++ b/jsons/Terrains.json
@@ -1,25 +1,28 @@
-[	
+[
 	// Base terrains
 	{
 		"name": "Ocean",
 		"type": "Water",
 		"movementCost": 1,
-		"RGB": [45,108,145]
+		"RGB": [45, 108, 145]
 	},
 	{
 		"name": "Coast",
 		"type": "Water",
 		"movementCost": 1,
-		"RGB": [107,167,193],
-		"uniques": ["[+2] to Fertility for Map Generation",
-			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."]
+		"RGB": [107, 167, 193],
+		"uniques": [
+			"[+2] to Fertility for Map Generation",
+			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
 	},
 	{
 		"name": "Grassland", // Wasteland
 		"type": "Land",
 		"movementCost": 1,
-		"RGB": [97,171,58],
-		"uniques": ["Occurs at temperature between [-0.4] and [0.1] and humidity between [0.2] and [0.4]",
+		"RGB": [97, 171, 58],
+		"uniques": [
+			"Occurs at temperature between [-0.4] and [0.1] and humidity between [0.2] and [0.4]",
 			"Occurs at temperature between [0.1] and [0.2] and humidity between [0.3] and [0.4]",
 			"Occurs at temperature between [-0.5] and [0.5] and humidity between [0.6] and [0.8]",
 			"Occurs at temperature between [-0.5] and [1] and humidity between [0.9] and [1]",
@@ -32,14 +35,16 @@
 			"A Region can not contain more [Plains] tiles than [Grassland] tiles",
 			"Considered [Desirable] when determining start locations",
 			"Considered [Food] when determining start locations",
-			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."]
+			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
 	},
 	{
 		"name": "Plains", // Badlands
 		"type": "Land",
 		"movementCost": 1,
-		"RGB": [168,185,102],
-		"uniques": ["Occurs at temperature between [-0.3] and [-0.1] and humidity between [0] and [0.2]",
+		"RGB": [168, 185, 102],
+		"uniques": [
+			"Occurs at temperature between [-0.3] and [-0.1] and humidity between [0] and [0.2]",
 			"Occurs at temperature between [-0.4] and [0.4] and humidity between [0.4] and [0.6]",
 			"Occurs at temperature between [0.4] and [0.5] and humidity between [0.5] and [0.6]",
 			"Occurs at temperature between [-0.6] and [0.7] and humidity between [0.8] and [0.9]",
@@ -49,20 +54,21 @@
 			"Occurs at temperature between [0.8] and [0.9] and humidity between [0.2] and [0.6]",
 			"Occurs at temperature between [0.7] and [0.8] and humidity between [0.3] and [0.4]",
 			"Occurs at temperature between [0.6] and [0.8] and humidity between [0.6] and [0.7]",
-			"Occurs at temperature between [0.5] and [0.7] and humidity between [0.7] and [0.8]",
 			"[+4] to Fertility for Map Generation",
 			"A Region is formed with at least [30]% [Plains] tiles, with priority [6]",
 			"A Region can not contain more [Grassland] tiles than [Plains] tiles",
 			"Considered [Desirable] when determining start locations",
 			"Considered [Food] when determining start locations",
-			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."]
+			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
 	},
 	{
 		"name": "Tundra",
 		"type": "Land",
 		"movementCost": 1,
-		"RGB": [189,204,191],
-		"uniques": ["Occurs at temperature between [-0.9] and [-0.6] and humidity between [0.8] and [1]",
+		"RGB": [189, 204, 191],
+		"uniques": [
+			"Occurs at temperature between [-0.9] and [-0.6] and humidity between [0.8] and [1]",
 			"Occurs at temperature between [-0.8] and [-0.5] and humidity between [0.6] and [0.8]",
 			"Occurs at temperature between [-0.7] and [-0.4] and humidity between [0.4] and [0.6]",
 			"Occurs at temperature between [-0.6] and [-0.4] and humidity between [0.2] and [0.4]",
@@ -71,14 +77,16 @@
 			"A Region is formed with at least [30]% [Tundra] tiles and [Snow] tiles, with priority [1]",
 			"Considered [Desirable] when determining start locations",
 			"Considered [Food] when determining start locations",
-			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."]
+			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
 	},
 	{
 		"name": "Desert",
 		"type": "Land",
 		"movementCost": 1,
-		"RGB": [ 230, 230, 113],
-		"uniques": ["Occurs at temperature between [-0.1] and [0.9] and humidity between [0] and [0.2]",
+		"RGB": [230, 230, 113],
+		"uniques": [
+			"Occurs at temperature between [-0.1] and [0.9] and humidity between [0] and [0.2]",
 			"Occurs at temperature between [0.1] and [0.8] and humidity between [0.2] and [0.3]",
 			"Occurs at temperature between [0.2] and [0.7] and humidity between [0.3] and [0.4]",
 			"Occurs at temperature between [0.4] and [0.6] and humidity between [0.4] and [0.5]",
@@ -87,17 +95,20 @@
 			"A Region is formed with at least [25]% [Desert] tiles, with priority [4]",
 			"Considered [Desirable] when determining start locations",
 			"Considered [Food] when determining start locations",
-			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."]
+			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
 	},
 	{
 		"name": "Lakes",
 		"type": "Water",
 		"food": 1,
 		"gold": 1,
-		"RGB": [ 123, 202, 226],
-		"uniques": ["Fresh water",
+		"RGB": [123, 202, 226],
+		"uniques": [
+			"Fresh water",
 			"Considered [Food] when determining start locations",
-			"Considered [Desirable] when determining start locations"]
+			"Considered [Desirable] when determining start locations"
+		]
 	},
 	{
 		"name": "Mountain",
@@ -105,27 +116,31 @@
 		"impassable": true,
 		"defenceBonus": 0.25,
 		"RGB": [120, 120, 120],
-		"uniques":["Rough terrain",
+		"uniques": [
+			"Rough terrain",
 			"Has an elevation of [4] for visibility calculations",
 			"Occurs in chains at high elevations",
 			"Units ending their turn on this terrain take [50] damage",
 			"Always Fertility [-2] for Map Generation",
-			"Considered [Undesirable] when determining start locations"]
+			"Considered [Undesirable] when determining start locations"
+		]
 	},
 	{
 		"name": "Snow", //Permafrost
 		"type": "Land",
 		"movementCost": 1,
 		"RGB": [231, 242, 249],
-		"uniques": ["Occurs at temperature between [-1] and [-0.9] and humidity between [0] and [1]",
+		"uniques": [
+			"Occurs at temperature between [-1] and [-0.9] and humidity between [0] and [1]",
 			"Occurs at temperature between [-0.9] and [-0.8] and humidity between [0] and [0.8]",
 			"Occurs at temperature between [-0.8] and [-0.7] and humidity between [0] and [0.6]",
 			"Occurs at temperature between [-0.7] and [-0.6] and humidity between [0] and [0.4]",
 			"Occurs at temperature between [-0.6] and [-0.5] and humidity between [0] and [0.2]",
 			"Considered [Undesirable] when determining start locations",
-			"Every [17] tiles with this terrain will receive a major deposit of a strategic resource."]
+			"Every [17] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
 	},
-	
+
 	// Terrain features
 	{
 		"name": "Hill",
@@ -134,9 +149,10 @@
 		"movementCost": 2,
 		"overrideStats": true,
 		"defenceBonus": 0.25,
-		"RGB": [105,125,72],
-		"occursOn": ["Tundra","Plains","Grassland","Desert","Snow"],
-		"uniques": ["Rough terrain",
+		"RGB": [105, 125, 72],
+		"occursOn": ["Tundra", "Plains", "Grassland", "Desert", "Snow"],
+		"uniques": [
+			"Rough terrain",
 			"[+5] Strength for cities built on this terrain",
 			"Has an elevation of [2] for visibility calculations",
 			"Occurs in groups around high elevations",
@@ -145,7 +161,8 @@
 			"Base Terrain on this tile is not counted for Region determination",
 			"Considered [Desirable] when determining start locations",
 			"Considered [Production] when determining start locations",
-			"Every [22] tiles with this terrain will receive a major deposit of a strategic resource."]
+			"Every [22] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
 	},
 	{
 		"name": "Forest", // Rubble
@@ -155,8 +172,9 @@
 		"overrideStats": true,
 		"unbuildable": true,
 		"defenceBonus": 0.25,
-		"occursOn": ["Desert","Tundra","Plains","Grassland","Hill","Snow"],
-		"uniques": ["Provides a one-time Production bonus to the closest city when cut down",
+		"occursOn": ["Desert", "Tundra", "Plains", "Grassland", "Hill", "Snow"],
+		"uniques": [
+			"Provides a one-time Production bonus to the closest city when cut down",
 			"Rough terrain",
 			"Blocks line-of-sight from tiles at same elevation",
 			"Resistant to nukes",
@@ -166,7 +184,8 @@
 			"A Region can not contain more [Jungle] tiles than [Forest] tiles",
 			"Considered [Desirable] when determining start locations",
 			"Considered [Production] when determining start locations",
-			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."]
+			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
 	},
 	{
 		"name": "Jungle", // Ruins
@@ -176,8 +195,9 @@
 		"overrideStats": true,
 		"unbuildable": true,
 		"defenceBonus": 0.25,
-		"occursOn": ["Desert","Tundra","Plains","Grassland","Hill","Snow"],
-		"uniques": ["Provides a one-time Production bonus to the closest city when cut down",
+		"occursOn": ["Desert", "Tundra", "Plains", "Grassland", "Hill", "Snow"],
+		"uniques": [
+			"Provides a one-time Production bonus to the closest city when cut down",
 			"Rough terrain",
 			"Blocks line-of-sight from tiles at same elevation",
 			"Resistant to nukes",
@@ -187,7 +207,8 @@
 			"A Region can not contain more [Forest] tiles than [Jungle] tiles",
 			"Considered [Desirable] when determining start locations",
 			"Considered [Production] when determining start locations",
-			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."]
+			"Every [33] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
 	},
 	{
 		"name": "Marsh", // Toxic Waste
@@ -195,34 +216,51 @@
 		"movementCost": 3,
 		"unbuildable": true,
 		"defenceBonus": -0.2,
-		"occursOn": ["Snow","Tundra","Plains","Grassland","Desert"],
-		"uniques": ["Nullifies all other stats this tile provides",
+		"occursOn": ["Snow", "Tundra", "Plains", "Grassland", "Desert"],
+		"uniques": [
+			"Nullifies all other stats this tile provides",
 			"Rare feature",
 			"Rough terrain",
 			"[-2] to Fertility for Map Generation",
-			"Every [9] tiles with this terrain will receive a major deposit of a strategic resource."]
-	},	
+			"Every [9] tiles with this terrain will receive a major deposit of a strategic resource."
+		]
+	},
 	{
 		"name": "Spring",
 		"type": "TerrainFeature",
 		"gold": 1,
-		"occursOn": ["Tundra","Plains","Grassland"],
-		"uniques": ["Rare feature",
+		"occursOn": ["Tundra", "Plains", "Grassland"],
+		"uniques": [
+			"Rare feature",
 			"Fresh water",
 			"Considered [Desirable] when determining start locations",
 			"Considered [Food] when determining start locations",
-			"Always Fertility [4] for Map Generation"]
-	},	
+			"Always Fertility [4] for Map Generation"
+		]
+	},
 	{
 		"name": "Fallout",
 		"type": "TerrainFeature",
 		"movementCost": 2,
 		"unbuildable": true,
-		"uniques": ["Nullifies all other stats this tile provides",
+		"uniques": [
+			"Nullifies all other stats this tile provides",
 			"Rare feature",
 			"[-2] to Fertility for Map Generation",
-			"Every [9] tiles with this terrain will receive a major deposit of a strategic resource."],
-		"occursOn": ["Grassland","Plains","Desert","Tundra","Snow","Forest","Jungle","Hill","Flood plains","Marsh"],
+			"Every [9] tiles with this terrain will receive a major deposit of a strategic resource."
+		],
+		"occursOn": [
+			"Grassland",
+			"Plains",
+			"Desert",
+			"Tundra",
+			"Snow",
+			"Forest",
+			"Jungle",
+			"Hill",
+			"Flood plains",
+			"Marsh"
+		],
 		"defenceBonus": -0.3
 	},
 	{
@@ -231,10 +269,12 @@
 		"food": 1,
 		"movementCost": 1,
 		"defenceBonus": -0.1,
-		"occursOn": ["Desert","Plains","Grassland"],
-		"uniques": ["Considered [Desirable] when determining start locations",
+		"occursOn": ["Desert", "Plains", "Grassland"],
+		"uniques": [
+			"Considered [Desirable] when determining start locations",
 			"Considered [Food] when determining start locations",
-			"Always Fertility [5] for Map Generation"]
+			"Always Fertility [5] for Map Generation"
+		]
 	},
 	{
 		"name": "Sunken Ruins",
@@ -251,10 +291,12 @@
 		"impassable": true,
 		"overrideStats": true,
 		"occursOn": ["Ocean", "Coast"],
-		"uniques": ["[-1] to Fertility for Map Generation",
-			"Considered [Undesirable] when determining start locations"]
+		"uniques": [
+			"[-1] to Fertility for Map Generation",
+			"Considered [Undesirable] when determining start locations"
+		]
 	},
- 
+
 	// Natural Wonders
 	{
 		"name": "Ship Graveyard", // was Great Barrier Reef
@@ -262,11 +304,13 @@
 		"production": 2,
 		"science": 1,
 		"occursOn": ["Ocean"],
-		"uniques": ["Must be adjacent to [1] to [6] [Coast] tiles",
+		"uniques": [
+			"Must be adjacent to [1] to [6] [Coast] tiles",
 			"Must be adjacent to [6] [Water] tiles",
 			"Occurs on latitudes from [10] to [70] percent of distance equator to pole",
 			"Occurs in groups of [2] to [2] tiles",
-			"Neighboring tiles will convert to [Coast]"],
+			"Neighboring tiles will convert to [Coast]"
+		],
 		"turnsInto": "Coast",
 		"impassable": true,
 		"unbuildable": true,
@@ -276,12 +320,14 @@
 		"name": "Army Depot", // was Old Faithful
 		"type": "NaturalWonder",
 		"culture": 1,
-		"occursOn": ["Grassland","Plains","Tundra","Mountain"],
-		"uniques": ["Must be adjacent to [0] [Coast] tiles",
+		"occursOn": ["Grassland", "Plains", "Tundra", "Mountain"],
+		"uniques": [
+			"Must be adjacent to [0] [Coast] tiles",
 			"Must be adjacent to [0] to [4] [Mountain] tiles",
 			"Must be adjacent to [3] to [6] [Elevated] tiles",
 			"Must be adjacent to [0] to [3] [Desert] tiles",
-			"Must be adjacent to [0] to [3] [Tundra] tiles"],
+			"Must be adjacent to [0] to [3] [Tundra] tiles"
+		],
 		"turnsInto": "Mountain",
 		"impassable": true,
 		"unbuildable": true,
@@ -296,8 +342,10 @@
 		"turnsInto": "Plains",
 		"impassable": true,
 		"unbuildable": true,
-		"uniques": ["Must be adjacent to [0] [Coast] tiles",
-			"Must be adjacent to [1] to [6] [Jungle] tiles"],
+		"uniques": [
+			"Must be adjacent to [0] [Coast] tiles",
+			"Must be adjacent to [1] to [6] [Jungle] tiles"
+		],
 		"weight": 2
 	},
 	{
@@ -310,8 +358,10 @@
 		"turnsInto": "Plains",
 		"impassable": true,
 		"unbuildable": true,
-		"uniques": ["Must be adjacent to [0] [Coast] tiles",
-			"Grants [Rejuvenation] ([all healing effects doubled]) to adjacent [Land] units for the rest of the game"],
+		"uniques": [
+			"Must be adjacent to [0] [Coast] tiles",
+			"Grants [Rejuvenation] ([all healing effects doubled]) to adjacent [Land] units for the rest of the game"
+		],
 		"weight": 1
 	},
 	{
@@ -321,11 +371,13 @@
 		"turnsInto": "Desert",
 		"food": 3,
 		"gold": 3,
-		"uniques": ["Must be adjacent to [0] [Coast] tiles",
+		"uniques": [
+			"Must be adjacent to [0] [Coast] tiles",
 			"Must be adjacent to [0] [Grassland] tiles",
 			"Must be adjacent to [2] to [6] [Hill] tiles",
 			"Must be adjacent to [0] to [2] [Mountain] tiles",
-			"Fresh water"],
+			"Fresh water"
+		],
 		"impassable": true,
 		"unbuildable": true,
 		"weight": 10
@@ -336,13 +388,15 @@
 		"gold": 1,
 		"culture": 1,
 		"happiness": 1,
-		"occursOn": ["Grassland","Plains"],
-		"uniques": ["Must be adjacent to [0] [Coast] tiles",
+		"occursOn": ["Grassland", "Plains"],
+		"uniques": [
+			"Must be adjacent to [0] [Coast] tiles",
 			"Must be adjacent to [0] [Tundra] tiles",
 			"Must be adjacent to [0] [Desert] tiles",
 			"Must be adjacent to [0] [Mountain] tiles",
 			"Must be adjacent to [0] [Marsh] tiles",
-			"Must be adjacent to [0] to [2] [Hill] tiles"],
+			"Must be adjacent to [0] to [2] [Hill] tiles"
+		],
 		"turnsInto": "Mountain",
 		"impassable": true,
 		"unbuildable": true,
@@ -352,10 +406,12 @@
 		"name": "Isolated Island", // was Krakatoa
 		"type": "NaturalWonder",
 		"occursOn": ["Ocean"],
-		"uniques": ["Must be adjacent to [1] to [6] [Coast] tiles",
+		"uniques": [
+			"Must be adjacent to [1] to [6] [Coast] tiles",
 			"Must be adjacent to [0] [Ice] tiles",
 			"Neighboring tiles will convert to [Coast]",
-			"Grants 500 Gold to the first civilization to discover it"],
+			"Grants 500 Gold to the first civilization to discover it"
+		],
 		"turnsInto": "Mountain",
 		"impassable": true,
 		"unbuildable": true,
@@ -367,10 +423,12 @@
 		"food": 1,
 		"science": 3,
 		"culture": 1,
-		"occursOn": ["Tundra","Snow"],
-		"uniques": ["Must be adjacent to [1] to [5] [Coast] tiles",
+		"occursOn": ["Tundra", "Snow"],
+		"uniques": [
+			"Must be adjacent to [1] to [5] [Coast] tiles",
 			"Must be adjacent to [1] [Mountain] tiles",
-			"Neighboring tiles except [Mountain] will convert to [Coast]"],
+			"Neighboring tiles except [Mountain] will convert to [Coast]"
+		],
 		"turnsInto": "Mountain",
 		"impassable": true,
 		"unbuildable": true,
@@ -381,9 +439,11 @@
 		"type": "NaturalWonder",
 		"gold": 2,
 		"science": 1,
-		"occursOn": ["Plains","Mountain"],
-		"uniques": ["Must be adjacent to [1] to [6] [Lakes] tiles",
-			"Fresh water"],
+		"occursOn": ["Plains", "Mountain"],
+		"uniques": [
+			"Must be adjacent to [1] to [6] [Lakes] tiles",
+			"Fresh water"
+		],
 		"turnsInto": "Mountain",
 		"impassable": true,
 		"unbuildable": true,
@@ -394,11 +454,13 @@
 		"type": "NaturalWonder",
 		"culture": 1,
 		"occursOn": ["Desert"],
-		"uniques": ["Must be adjacent to [0] [Coast] tiles",
+		"uniques": [
+			"Must be adjacent to [0] [Coast] tiles",
 			"Must be adjacent to [0] [Grassland] tiles",
 			"Must be adjacent to [0] to [2] [Mountain] tiles",
 			"Must be adjacent to [0] to [4] [Elevated] tiles",
-			"Must be adjacent to [1] to [6] [Mountain] tiles"],
+			"Must be adjacent to [1] to [6] [Mountain] tiles"
+		],
 		"turnsInto": "Mountain",
 		"impassable": true,
 		"unbuildable": true,
@@ -409,15 +471,17 @@
 		"type": "NaturalWonder",
 		"faith": 1,
 		"culture": 1,
-		"occursOn": ["Desert","Plains"],
-		"uniques": ["Must be adjacent to [0] [Coast] tiles",
+		"occursOn": ["Desert", "Plains"],
+		"uniques": [
+			"Must be adjacent to [0] [Coast] tiles",
 			"Must be adjacent to [0] [Grassland] tiles",
 			"Must be adjacent to [0] [Tundra] tiles",
 			"Must be adjacent to [0] [Marsh] tiles",
-			"Must be adjacent to [3] to [6] [Desert] tiles"],
+			"Must be adjacent to [3] to [6] [Desert] tiles"
+		],
 		"turnsInto": "Mountain",
 		"impassable": true,
 		"unbuildable": true,
 		"weight": 10
 	}
-]	
+]

--- a/jsons/Terrains.json
+++ b/jsons/Terrains.json
@@ -44,7 +44,7 @@
 		"movementCost": 1,
 		"RGB": [168, 185, 102],
 		"uniques": [
-			"Occurs at temperature between [-0.3] and [-0.1] and humidity between [0] and [0.2]",
+			"Occurs at temperature between [-0.4] and [-0.1] and humidity between [0] and [0.2]",
 			"Occurs at temperature between [-0.4] and [0.4] and humidity between [0.4] and [0.6]",
 			"Occurs at temperature between [0.4] and [0.5] and humidity between [0.5] and [0.6]",
 			"Occurs at temperature between [-0.6] and [0.7] and humidity between [0.8] and [0.9]",

--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -265,6 +265,7 @@
 		"uniques": [
 			"Great Improvement",
 			"Gives a defensive bonus of [10]%",
+			"[+1 Science] for each adjacent [Forest]",
 			"[+1 Science] for each adjacent [Jungle]",
 			"[+1 Food] for each adjacent [Farm]",
 			"[+1 Gold] <after discovering [Currency]>",

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1,4 +1,5 @@
 [
+	// Missiles
 	{
 		"name": "Divine Spear",
 		"unitType": "Missile",
@@ -7,11 +8,13 @@
 		"rangedStrength": 300,
 		"range": 8,
 		"cost": 1600,
-        "uniques": ["Only available <if [Faust Project] is constructed>",
+		"uniques": [
+			"Only available <if [Faust Project] is constructed>",
 			"Nuclear weapon of Strength [2]",
 			"Blast radius [2]",
 			"Unbuildable",
-			"Consumes [1] [Uranium]"],
+			"Consumes [1] [Uranium]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "nuke"
 	},
@@ -24,10 +27,12 @@
 		"range": 8,
 		"cost": 600,
 		"requiredTech": "Gyroscopes",
-		"uniques": ["Nuclear weapon of Strength [1]",
+		"uniques": [
+			"Nuclear weapon of Strength [1]",
 			"Blast radius [1]",
 			"Only available <if [Manhattan Project] is constructed>",
-			"Consumes [1] [Uranium]"],
+			"Consumes [1] [Uranium]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "nuke"
 	},
@@ -40,15 +45,17 @@
 		"range": 16,
 		"cost": 1000,
 		"requiredTech": "Rocketry",
-		"uniques": ["Nuclear weapon of Strength [2]",
+		"uniques": [
+			"Nuclear weapon of Strength [2]",
 			"Blast radius [2]",
 			"Only available <if [Manhattan Project] is constructed>",
-			"Consumes [1] [Uranium]"],
+			"Consumes [1] [Uranium]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "nuke"
 	},
-	
-	/* Ancient Era */
+
+	// Decivilized Era
 	{
 		"name": "Worker",
 		"unitType": "Civilian",
@@ -56,17 +63,19 @@
 		"hurryCostModifier": 20,
 		"uniques": ["Can build [Land] improvements on tiles"],
 		"cost": 70
-	},	
+	},
 	{
 		"name": "Mounted Worker",
 		"unitType": "Civilian",
 		"movement": 4,
 		"hurryCostModifier": 20,
 		"requiredTech": "Redomestication",
-		"uniques": ["Mounted",
+		"uniques": [
+			"Mounted",
 			"Can build [Land] improvements on tiles",
 			"May withdraw before melee ([50]%)",
-			"Only available <in cities with a [Stable]>"],
+			"Only available <in cities with a [Stable]>"
+		],
 		"cost": 130
 	},
 	{
@@ -74,41 +83,42 @@
 		"unitType": "Civilian",
 		"movement": 3,
 		"cost": 106,
-		"uniques": ["Founds a new city",
+		"uniques": [
+			"Founds a new city",
 			"[+15] HP when healing",
 			"All adjacent units heal [+15] HP when healing",
 			"Excess Food converted to Production when under construction",
-			"Requires at least [2] population"],
+			"Requires at least [2] population"
+		],
 		"hurryCostModifier": 20
-	},	
+	},
 	{
 		"name": "Work Boats",
 		"unitType": "Civilian Water",
 		"movement": 4,
 		"cost": 30,
 		"requiredTech": "Sailing",
-		"uniques": ["Cannot enter ocean tiles <before discovering [Astronomy]>",
-			"May create improvements on water resources"],
+		"uniques": [
+			"Cannot enter ocean tiles <before discovering [Astronomy]>",
+			"May create improvements on water resources"
+		],
 		"hurryCostModifier": 20
 	},
-	
+
+	// Low Tech
 	{
 		"name": "Scout",
 		"unitType": "Scout",
 		"movement": 2,
 		"strength": 12,
-		"cost": 25,		
+		"cost": 25,
 		"upgradesTo": "Gunman",
 		"hurryCostModifier": 20,
 		"obsoleteTech": "Rifling",
-		"uniques": ["Low Tech",
-			"[-50]% Strength <vs cities>"],
-		"promotions": ["Reconnaissance I","Skirmish"],
+		"uniques": ["Low Tech", "[-50]% Strength <vs cities>"],
+		"promotions": ["Reconnaissance I", "Skirmish"],
 		"attackSound": "nonmetalhit"
-	},		
-
-//	Infantry  LOW TECH	
-	
+	},
 	{
 		"name": "Warrior",
 		"unitType": "Scrapper",
@@ -120,14 +130,14 @@
 		"upgradesTo": "Militia",
 		"hurryCostModifier": 20,
 		"obsoleteTech": "Rifling",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"[+50]% Strength <vs [Mounted] units>",
-			"Consumes [1] [Slaves]"],
+			"Consumes [1] [Slaves]"
+		],
 		"promotions": ["Raider"],
 		"attackSound": "nonmetalhit"
-	},		
-
-
+	},
 	{
 		"name": "Spearman",
 		"unitType": "Scrapper",
@@ -137,10 +147,9 @@
 		"upgradesTo": "Militia",
 		"hurryCostModifier": 20,
 		"obsoleteTech": "Rifling",
-		"uniques": ["Low Tech",
-			"[+50]% Strength <vs [Mounted] units>"],
+		"uniques": ["Low Tech", "[+50]% Strength <vs [Mounted] units>"],
 		"attackSound": "nonmetalhit"
-	},	
+	},
 	{
 		"name": "Scavenger",
 		"unitType": "Scrapper",
@@ -165,12 +174,14 @@
 		"cost": 50,
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Militia",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"Only available <if [Clubhouse] is constructed>",
-			"[+50]% Strength <vs [Mounted] units>"],
+			"[+50]% Strength <vs [Mounted] units>"
+		],
 		"promotions": ["Clansman"],
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Auxiliary",
 		"unitType": "Scrapper",
@@ -179,15 +190,17 @@
 		"cost": 20,
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Militia",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
 			"[+50]% Strength <vs [Mounted] units>",
 			"Consumes [1] [Slaves]",
 			"Only available <with [Slaves]>",
-			"Never appears as a Barbarian unit"],
+			"Never appears as a Barbarian unit"
+		],
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Rubble Gang",
 		"unitType": "Scrapper",
@@ -198,10 +211,12 @@
 		"cost": 15,
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Rubble Militia",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"Consumes [1] [Slaves]",
-			"Only available <with [Slaves]>"],
-		"promotions": ["Forage","Urban Warfare I"],
+			"Only available <with [Slaves]>"
+		],
+		"promotions": ["Forage", "Urban Warfare I"],
 		"attackSound": "nonmetalhit"
 	},
 	{
@@ -214,9 +229,11 @@
 		"cost": 50,
 		"upgradesTo": "Militia",
 		"hurryCostModifier": 20,
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"Can build [Land] improvements on tiles",
-			"[+50]% Strength <when defending>"],
+			"[+50]% Strength <when defending>"
+		],
 		"promotions": ["Medic I"],
 		"attackSound": "nonmetalhit"
 	},
@@ -232,11 +249,13 @@
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Legion",
 		"hurryCostModifier": 20,
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"[+25]% Strength <vs cities>",
-			"[+25]% Strength <vs [Low Tech] units>"],
+			"[+25]% Strength <vs [Low Tech] units>"
+		],
 		"attackSound": "metalhit"
-	},		
+	},
 	{
 		"name": "Legion",
 		"unitType": "Scrapper",
@@ -248,12 +267,14 @@
 		"requiredTech": "Iron Working",
 		"obsoleteTech": "Combined Arms",
 		"upgradesTo": "Soldier",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"[+50]% Strength <vs cities>",
 			"[+50]% Strength <vs [Low Tech] units>",
-			"Only available <if [Forge] is constructed>"],
+			"Only available <if [Forge] is constructed>"
+		],
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Archer",
 		"unitType": "Shooter",
@@ -266,10 +287,9 @@
 		"requiredTech": "Iron Working",
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Gunman",
-		"uniques": ["Low Tech",
-			"[+33]% Strength <vs [Low Tech] units>"],
+		"uniques": ["Low Tech", "[+33]% Strength <vs [Low Tech] units>"],
 		"attackSound": "arrow"
-	},		
+	},
 	{
 		"name": "Crossbowman",
 		"unitType": "Shooter",
@@ -282,14 +302,16 @@
 		"requiredTech": "Iron Working",
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Gunman",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
 			"[+33]% Strength <vs [Low Tech] units>",
 			"Consumes [1] [Slaves]",
-			"Only available <with [Slaves]>"],
+			"Only available <with [Slaves]>"
+		],
 		"attackSound": "arrow"
-	},		
+	},
 	{
 		"name": "Rubble Archer",
 		"unitType": "Shooter",
@@ -304,32 +326,37 @@
 		"requiredTech": "Iron Working",
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Rubble Gunman",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"[+33]% Strength <vs [Low Tech] units>",
 			"Consumes [1] [Slaves]",
-			"Only available <with [Slaves]>"],
+			"Only available <with [Slaves]>"
+		],
 		"promotions": ["Urban Warfare I"],
 		"attackSound": "arrow"
-	},	
-	//cavalry
+	},
+
+	// Cavalry
 	{
 		"name": "Horseman",
 		"unitType": "Mounted",
 		"movement": 4,
 		"strength": 20,
 		"cost": 70,
-	//	"requiredTech": "Redomestication",
+		// "requiredTech": "Redomestication",
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Hussar",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"[+50]% Strength <vs [Low Tech] units>",
 			"No defensive terrain bonus",
 			"Can move after attacking",
 			"[-25]% Strength <vs cities>",
-			"Only available <in cities with a [Stable]>"],
+			"Only available <in cities with a [Stable]>"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "horse"
-	},	
+	},
 	{
 		"name": "Hussar",
 		"unitType": "Mounted",
@@ -340,15 +367,17 @@
 		"requiredTech": "Redomestication",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Cavalry",
-		"uniques": ["Personnel",
+		"uniques": [
+			"Personnel",
 			"No defensive terrain bonus",
 			"Can move after attacking",
 			"[-50]% Strength <vs cities>",
 			"Only available <in cities with a [Stable]>",
-			"Consumes [1] [Weapons]"],
+			"Consumes [1] [Weapons]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"
-	},	
+	},
 	{
 		"name": "Cavalry",
 		"unitType": "Mounted",
@@ -358,11 +387,13 @@
 		"cost": 120,
 		"requiredTech": "Rifling",
 		"upgradesTo": "Tank",
-		"uniques": ["Personnel",
+		"uniques": [
+			"Personnel",
 			"No defensive terrain bonus",
 			"Can move after attacking",
 			"[-50]% Strength <vs cities>",
-			"Only available <in cities with a [Stable]>"],
+			"Only available <in cities with a [Stable]>"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"
 	},
@@ -377,14 +408,16 @@
 		"requiredTech": "Iron Working",
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Dragoon",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"Can move after attacking",
 			"[+33]% Strength <vs [Low Tech] units>",
 			"[-33]% Strength <vs cities>",
-			"Only available <in cities with a [Stable]>"],
+			"Only available <in cities with a [Stable]>"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "horse"
-	},	
+	},
 	{
 		"name": "Dragoon",
 		"unitType": "Shooter",
@@ -396,11 +429,13 @@
 		"requiredTech": "Redomestication",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Light Cavalry",
-		"uniques": ["Personnel",
+		"uniques": [
+			"Personnel",
 			"Can move after attacking",
 			"[-33]% Strength <vs cities>",
 			"Only available <in cities with a [Stable]>",
-			"Consumes [1] [Weapons]"],
+			"Consumes [1] [Weapons]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"
 	},
@@ -414,13 +449,15 @@
 		"cost": 115,
 		"requiredTech": "Rifling",
 		"upgradesTo": "Helicopter",
-		"uniques": ["Personnel",
+		"uniques": [
+			"Personnel",
 			"Can move after attacking",
 			"[-33]% Strength <vs cities>",
-			"Only available <in cities with a [Stable]>"],
+			"Only available <in cities with a [Stable]>"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"
-	},	
+	},
 	{
 		"name": "Security",
 		"unitType": "Scrapper",
@@ -429,13 +466,12 @@
 		"movement": 2,
 		"strength": 36,
 		"cost": 190,
-		"upgradesTo": "Infantry",		
-		"uniques": ["Personnel",
-			"Unbuildable"],
-		"promotions": ["Hazard Pay","Tear Gas"],
+		"upgradesTo": "Infantry",
+		"uniques": ["Personnel", "Unbuildable"],
+		"promotions": ["Hazard Pay", "Tear Gas"],
 		"hurryCostModifier": -33,
 		"attackSound": "shot"
-	},		
+	},
 	{
 		"name": "Militia",
 		"unitType": "Scrapper",
@@ -445,12 +481,11 @@
 		"cost": 55,
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
-		"upgradesTo": "Soldier",		
-		"uniques": ["Personnel",
-			"Consumes [1] [Weapons]"],
+		"upgradesTo": "Soldier",
+		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Guerilla",
 		"unitType": "Scrapper",
@@ -463,12 +498,11 @@
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Soldier",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
-			"Consumes [1] [Weapons]"],
+		"hurryCostModifier": 20,
+		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
 		"promotions": ["Forage"],
 		"attackSound": "shot"
-	},	
+	},
 	{
 		"name": "Panther",
 		"unitType": "Scrapper",
@@ -480,17 +514,14 @@
 		"cost": 55,
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
-		"upgradesTo": "Soldier",		
-		"uniques": ["Personnel",
-			"Consumes [1] [Weapons]"],
+		"upgradesTo": "Soldier",
+		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
 		"hurryCostModifier": 20,
 		"promotions": ["Raider"],
 		"attackSound": "machinegun"
 	},
 
-
-	//t1
-		
+	// T1
 	{
 		"name": "Soldier",
 		"unitType": "Scrapper",
@@ -501,10 +532,10 @@
 		"upgradesTo": "Infantry",
 		"hurryCostModifier": 20,
 		"requiredTech": "Rifling",
-		//"obsoleteTech": "Combined Arms",		
+		// "obsoleteTech": "Combined Arms",
 		"uniques": ["Personnel"],
 		"attackSound": "machinegun"
-	},		
+	},
 	{
 		"name": "Conscript",
 		"unitType": "Scrapper",
@@ -514,15 +545,17 @@
 		"cost": 60,
 		"upgradesTo": "Infantry",
 		"hurryCostModifier": 20,
-		"requiredTech": "Rifling",	
-		"obsoleteTech": "Combined Arms",		
-		"uniques": ["Personnel",
+		"requiredTech": "Rifling",
+		"obsoleteTech": "Combined Arms",
+		"uniques": [
+			"Personnel",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
 			"Only available <with [Slaves]>",
-			"Consumes [1] [Slaves]"],
+			"Consumes [1] [Slaves]"
+		],
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Rubble Militia",
 		"unitType": "Scrapper",
@@ -534,15 +567,17 @@
 		"cost": 60,
 		"upgradesTo": "Henchman",
 		"hurryCostModifier": 20,
-		"requiredTech": "Rifling",	
-		"obsoleteTech": "Combined Arms",		
-		"uniques": ["Low Tech",
+		"requiredTech": "Rifling",
+		"obsoleteTech": "Combined Arms",
+		"uniques": [
+			"Low Tech",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
 			"Only available <with [Slaves]>",
-			"Consumes [1] [Slaves]"],
+			"Consumes [1] [Slaves]"
+		],
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Infantry",
 		"unitType": "Scrapper",
@@ -552,11 +587,10 @@
 		"cost": 125,
 		"requiredTech": "Replaceable Parts",
 		"upgradesTo": "NBC Infantry",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
-			"Consumes [1] [Weapons]"],
+		"hurryCostModifier": 20,
+		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Contractor",
 		"unitType": "Scrapper",
@@ -567,13 +601,12 @@
 		"strength": 45,
 		"cost": 225,
 		"upgradesTo": "NBC Infantry",
-		"requiredTech": "Currency",	
-		"uniques": ["Personnel",
-			"Consumes [1] [Weapons]"],
-		"promotions": ["Hazard Pay","Drone Recon"],
+		"requiredTech": "Currency",
+		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
+		"promotions": ["Hazard Pay", "Drone Recon"],
 		"hurryCostModifier": -25,
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Marine",
 		"uniqueTo": "The Patriots",
@@ -585,13 +618,15 @@
 		"cost": 175,
 		"requiredTech": "The Wheel",
 		"upgradesTo": "NBC Infantry",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
+		"hurryCostModifier": 20,
+		"uniques": [
+			"Personnel",
 			"Only available <if [Armory] is constructed>",
-			"Consumes [1] [Weapons]"],
-		"promotions": ["Amphibious","Gas Mask"],
+			"Consumes [1] [Weapons]"
+		],
+		"promotions": ["Amphibious", "Gas Mask"],
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Black Hand",
 		"unitType": "Scrapper",
@@ -601,14 +636,16 @@
 		"movement": 2,
 		"strength": 45,
 		"cost": 225,
-		"requiredTech": "Currency",	
-		"uniques": ["Personnel",
+		"requiredTech": "Currency",
+		"uniques": [
+			"Personnel",
 			"Only available <if [Grand Clan Manor] is constructed>",
-			"Consumes [1] [Weapons]"],
-		"promotions": ["Gas Mask","Reconnaissance I"],
+			"Consumes [1] [Weapons]"
+		],
+		"promotions": ["Gas Mask", "Reconnaissance I"],
 		"hurryCostModifier": 25,
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "NBC Infantry",
 		"unitType": "Scrapper",
@@ -618,12 +655,14 @@
 		"cost": 230,
 		"requiredTech": "Plastics",
 		"hurryCostModifier": 20,
-		"uniques": ["Personnel",
+		"uniques": [
+			"Personnel",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Weapons]"],
+			"Consumes [1] [Weapons]"
+		],
 		"promotions": ["Gas Mask"],
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "NBC Conscript",
 		"unitType": "Scrapper",
@@ -632,14 +671,16 @@
 		"strength": 36,
 		"cost": 125,
 		"requiredTech": "Plastics",
-	//	"upgradesTo": "NBC Infantry", ??
+		// "upgradesTo": "NBC Infantry", ??
 		"hurryCostModifier": 20,
-		"uniques": ["Personnel",
+		"uniques": [
+			"Personnel",
 			"Only available <if [Factory] is constructed>",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
 			"Only available <with [Slaves]>",
-			"Consumes [1] [Slaves]"],
+			"Consumes [1] [Slaves]"
+		],
 		"promotions": ["Gas Mask"],
 		"attackSound": "machinegun"
 	},
@@ -654,16 +695,19 @@
 		"cost": 125,
 		"requiredTech": "Plastics",
 		"hurryCostModifier": 20,
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"Only available <if [Factory] is constructed>",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
 			"Only available <with [Slaves]>",
-			"Consumes [1] [Slaves]"],
+			"Consumes [1] [Slaves]"
+		],
 		"promotions": ["Gas Mask"],
 		"attackSound": "machinegun"
 	},
-	/*{
+	/*
+	{
 		"name": "Exo-Suit",
 		"unitType": "Armor",
 		"interceptRange": 1,
@@ -675,8 +719,8 @@
 		"hurryCostModifier": 50,
 		"uniques": ["Only available <if [Factory] is constructed>"],
 		"attackSound": "machinegun"
-	},*/
-	/*{
+	},
+	{
 		"name": "Combat Suit",
 		"unitType": "Scrapper",
 		"interceptRange": 1,
@@ -687,10 +731,10 @@
 		"hurryCostModifier": 20,
 		"uniques": ["Requires [Suit Factory]","No defensive terrain bonus"],
 		"attackSound": "machinegun"
-	},*/
-	//range
-	
-	
+	},
+	*/
+
+	// Range
 	{
 		"name": "Gunman",
 		"unitType": "Shooter",
@@ -702,11 +746,10 @@
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Rifleman",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
-			"Consumes [1] [Weapons]"],
+		"hurryCostModifier": 20,
+		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
 		"attackSound": "shot"
-	},		
+	},
 	{
 		"name": "Hitman",
 		"unitType": "Shooter",
@@ -720,12 +763,11 @@
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Assassin",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
-			"Consumes [1] [Weapons]"],
-		"promotions": ["Headhunter","Skirmish","Reconnaissance I"],
+		"hurryCostModifier": 20,
+		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
+		"promotions": ["Headhunter", "Skirmish", "Reconnaissance I"],
 		"attackSound": "shot"
-	},		
+	},
 	{
 		"name": "Rubble Gunman",
 		"unitType": "Shooter",
@@ -739,15 +781,17 @@
 		"requiredTech": "Rifling",
 		"obsoleteTech": "Combined Arms",
 		"upgradesTo": "Machine Gun",
-		"hurryCostModifier": 20,		
-		"uniques": ["Low Tech",
+		"hurryCostModifier": 20,
+		"uniques": [
+			"Low Tech",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
 			"Only available <with [Slaves]>",
-			"Consumes [1] [Slaves]"],
+			"Consumes [1] [Slaves]"
+		],
 		"promotions": ["Urban Warfare I"],
 		"attackSound": "shot"
-	},	
+	},
 	{
 		"name": "Rifleman",
 		"unitType": "Shooter",
@@ -759,10 +803,10 @@
 		"requiredTech": "Rifling",
 		"obsoleteTech": "Combined Arms",
 		"upgradesTo": "Marksman",
-		"hurryCostModifier": 20,		
+		"hurryCostModifier": 20,
 		"uniques": ["Personnel"],
 		"attackSound": "shot"
-	},	
+	},
 	{
 		"name": "Marksman",
 		"unitType": "Shooter",
@@ -773,13 +817,13 @@
 		"cost": 125,
 		"requiredTech": "Replaceable Parts",
 		"upgradesTo": "NBC Marksman",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
-			"Consumes [1] [Weapons]"],
+		"hurryCostModifier": 20,
+		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
 		"promotions": ["Reconnaissance I"],
 		"attackSound": "shot"
-	},	
-	/*{
+	},
+	/*
+	{
 		"name": "Sniper",
 		"unitType": "Shooter",
 		"uniqueTo": "The Patriots",
@@ -796,7 +840,8 @@
 			"Consumes [1] [Weapons]"],
 		"promotions": ["Reconnaissance I","Extended Range"],
 		"attackSound": "shot"
-	},	*/	
+	},
+	*/
 	{
 		"name": "Spec Ops",
 		"unitType": "Shooter",
@@ -808,13 +853,15 @@
 		"rangedStrength": 35,
 		"cost": 300,
 		"hurryCostModifier": 20,
-		"requiredTech": "The Wheel",	
-		"uniques": ["Personnel",
+		"requiredTech": "The Wheel",
+		"uniques": [
+			"Personnel",
 			"Only available <if [Armory] is constructed>",
-			"Consumes [1] [Weapons]"],
-		"promotions": ["Reconnaissance I","Amphibious","Ambush","Gas Mask"],
+			"Consumes [1] [Weapons]"
+		],
+		"promotions": ["Reconnaissance I", "Amphibious", "Ambush", "Gas Mask"],
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Assassin",
 		"unitType": "Shooter",
@@ -826,12 +873,11 @@
 		"rangedStrength": 35,
 		"cost": 200,
 		"requiredTech": "Currency",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
-			"Consumes [1] [Weapons]"],
-		"promotions": ["Headhunter","Skirmish","Reconnaissance I"],
+		"hurryCostModifier": 20,
+		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
+		"promotions": ["Headhunter", "Skirmish", "Reconnaissance I"],
 		"attackSound": "shot"
-	},		
+	},
 	{
 		"name": "Ranger",
 		"unitType": "Shooter",
@@ -840,8 +886,9 @@
 		"range": 1,
 		"movement": 2,
 		"strength": 35,
-		"rangedStrength": 35,	
-		"uniques": ["Personnel",
+		"rangedStrength": 35,
+		"uniques": [
+			"Personnel",
 			"[+20]% Strength <when fighting in [Friendly Land] tiles>",
 			"Bonus for units in 2 tile radius 15%",
 			"[50]% XP gained from combat",
@@ -850,8 +897,9 @@
 			"Unbuildable",
 			"Uncapturable",
 			"[Great General] is earned [-33]% faster",
-			"Consumes [1] [Weapons]"],
-		"promotions": ["Reconnaissance I","Gas Mask"],
+			"Consumes [1] [Weapons]"
+		],
+		"promotions": ["Reconnaissance I", "Gas Mask"],
 		"attackSound": "shot"
 	},
 	{
@@ -862,15 +910,18 @@
 		"strength": 30,
 		"rangedStrength": 35,
 		"cost": 225,
-		"requiredTech": "Plastics",		
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
+		"requiredTech": "Plastics",
+		"hurryCostModifier": 20,
+		"uniques": [
+			"Personnel",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Weapons]"],
-		"promotions": ["Reconnaissance I","Gas Mask"],
+			"Consumes [1] [Weapons]"
+		],
+		"promotions": ["Reconnaissance I", "Gas Mask"],
 		"attackSound": "shot"
-	},			
-	/*{
+	},
+	/*
+	{
 		"name": "Stealth Suit",
 		"unitType": "Shooter",
 		"range": 1,
@@ -883,10 +934,10 @@
 		"uniques": ["Personnel","Only available <if [Factory] is constructed>"],
 		"promotions": ["Reconnaissance I","Gas Mask","Extended Range"],
 		"attackSound": "shot"
-	},*/
-	
-	//siege
-	
+	},
+	*/
+
+	// Siege
 	{
 		"name": "Cannon",
 		"unitType": "Siege",
@@ -897,12 +948,14 @@
 		"requiredTech": "Steel",
 		"upgradesTo": "Artillery",
 		"obsoleteTech": "Munitions",
-		"uniques": ["[+20]% Strength <vs [Low Tech] units>",
+		"uniques": [
+			"[+20]% Strength <vs [Low Tech] units>",
 			"[+100]% Strength <vs cities>",
 			"No defensive terrain bonus",
 			"Must set up to ranged attack",
 			"[-1] Sight",
-			"Only available <if [Blast Furnace] is constructed>"],
+			"Only available <if [Blast Furnace] is constructed>"
+		],
 		"attackSound": "cannon"
 	},
 	{
@@ -917,11 +970,13 @@
 		"requiredTech": "Machinery",
 		"upgradesTo": "Artillery",
 		"obsoleteTech": "Munitions",
-		"uniques": ["[+33]% Strength <vs [Low Tech] units>",
+		"uniques": [
+			"[+33]% Strength <vs [Low Tech] units>",
 			"[+100]% Strength <vs cities>",
 			"No defensive terrain bonus",
 			"Must set up to ranged attack",
-			"[-1] Sight"],
+			"[-1] Sight"
+		],
 		"attackSound": "throw"
 	},
 	{
@@ -934,8 +989,10 @@
 		"cost": 150,
 		"requiredTech": "Munitions",
 		"upgradesTo": "Missile Vehicle",
-		"uniques": ["[+200]% Strength <vs [Armor] units>",
-			"Only available <if [Factory] is constructed>"],
+		"uniques": [
+			"[+200]% Strength <vs [Armor] units>",
+			"Only available <if [Factory] is constructed>"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
 	},
@@ -949,16 +1006,18 @@
 		"cost": 185,
 		"requiredTech": "Munitions",
 		"upgradesTo": "Rocket Artillery",
-		"uniques": ["[+100]% Strength <vs cities>",
+		"uniques": [
+			"[+100]% Strength <vs cities>",
 			"No defensive terrain bonus",
 			"[-50]% Strength <vs [Helicopter] units>",
 			"Must set up to ranged attack",
 			"[-1] Sight",
-			"Only available <if [Factory] is constructed>"],
+			"Only available <if [Factory] is constructed>"
+		],
 		"promotions": ["Artillery"],
 		"hurryCostModifier": 20,
 		"attackSound": "artillery"
-	},	
+	},
 	{
 		"name": "Machine Gun",
 		"unitType": "Siege",
@@ -968,10 +1027,12 @@
 		"rangedStrength": 50,
 		"cost": 150,
 		"requiredTech": "Replaceable Parts",
-		"uniques": ["Must set up to ranged attack",
+		"uniques": [
+			"Must set up to ranged attack",
 			"[-33]% Strength <vs [Armor] units>",
 			"[-50]% Strength <vs cities>",
-			"Only available <if [Factory] is constructed>"],
+			"Only available <if [Factory] is constructed>"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
 	},
@@ -985,19 +1046,20 @@
 		"rangedStrength": 50,
 		"cost": 185,
 		"requiredTech": "Ballistics",
-		"uniques": ["[75]% chance to intercept air attacks",
+		"uniques": [
+			"[75]% chance to intercept air attacks",
 			"[+50]% Strength <vs [Air] units>",
 			"[+100]% Strength <vs [Helicopter] units>",
 			"[-33]% Strength <vs [Armor] units>",
 			"[-50]% Strength <vs cities>",
 			"Must set up to ranged attack",
-			"Only available <if [Factory] is constructed>"],
+			"Only available <if [Factory] is constructed>"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
 	},
 
-	
-	//armor
+	// Armor
 	{
 		"name": "Attack Vehicle",
 		"unitType": "Armor",
@@ -1007,14 +1069,16 @@
 		"requiredTech": "Machinery",
 		"upgradesTo": "Armored Car",
 		"obsoleteTech": "Replaceable Parts",
-		"uniques": ["[+20]% Strength <vs [Low Tech] units>",
+		"uniques": [
+			"[+20]% Strength <vs [Low Tech] units>",
 			"[-66]% Strength <vs cities>",
 			"Can move after attacking",
 			"No defensive terrain bonus",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
-	},		
+	},
 	{
 		"name": "War Buggy",
 		"unitType": "Armor",
@@ -1026,21 +1090,20 @@
 		"requiredTech": "Machinery",
 		"upgradesTo": "Armored Car",
 		"obsoleteTech": "Combined Arms",
-		"uniques": ["[+20]% Strength <vs [Low Tech] units>",
+		"uniques": [
+			"[+20]% Strength <vs [Low Tech] units>",
 			"[-66]% Strength <vs cities>",
 			"Can move after attacking",
 			"No defensive terrain bonus",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"promotions": ["Raider"],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
-	},	
-	
+	},
 
-/* Tier 1 */
-	
+	// T1
 	{
-
 		"name": "Armored Car",
 		"unitType": "Armor",
 		"movement": 4,
@@ -1049,17 +1112,18 @@
 		"requiredTech": "Replaceable Parts",
 		"upgradesTo": "Tank",
 		"obsoleteTech": "Combined Arms",
-		"uniques": ["[-33]% Strength <vs [Armor] units>",
+		"uniques": [
+			"[-33]% Strength <vs [Armor] units>",
 			"[-33]% Strength <vs cities>",
 			"Can move after attacking",
 			"No defensive terrain bonus",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
-	},		
+	},
 	{
-
 		"name": "Demolition Track",
 		"unitType": "Armor",
 		"uniqueTo": "Cult of Ignis",
@@ -1070,17 +1134,18 @@
 		"requiredTech": "Iron Working",
 		"upgradesTo": "Tank",
 		"obsoleteTech": "Combined Arms",
-		"uniques": ["Only available <if [Chop Shop] is constructed>",
+		"uniques": [
+			"Only available <if [Chop Shop] is constructed>",
 			"[+50]% Strength <vs cities>",
 			"[+33]% Strength <vs [Ranged] units> <when defending>",
 			"Can move after attacking",
 			"No defensive terrain bonus",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
-	},	
+	},
 	{
-
 		"name": "Big Rig",
 		"unitType": "Armor",
 		"uniqueTo": "Cult of Ignis",
@@ -1091,13 +1156,15 @@
 		"requiredTech": "Engineering",
 		"upgradesTo": "Tank",
 		"obsoleteTech": "Combined Arms",
-		"uniques": ["Only available <if [Chop Shop] is constructed>",
+		"uniques": [
+			"Only available <if [Chop Shop] is constructed>",
 			"Can move after attacking",
 			"No defensive terrain bonus",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
-	},	
+	},
 	{
 		"name": "Technical",
 		"unitType": "Siege",
@@ -1109,21 +1176,19 @@
 		"requiredTech": "Replaceable Parts",
 		"upgradesTo": "Missile Vehicle",
 		"obsoleteTech": "Lasers",
-		"uniques": ["Can move after attacking",
+		"uniques": [
+			"Can move after attacking",
 			"No defensive terrain bonus",
 			"[-33]% Strength <vs [Armor] units>",
 			"[-50]% Strength <vs cities>",
 			"May withdraw before melee ([75]%)",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
-	},		
+	},
 
-
-	
-	//T2
-	
-
+	// T2
 	{
 		"name": "Tank",
 		"unitType": "Armor",
@@ -1133,18 +1198,18 @@
 		"requiredTech": "Combined Arms",
 		"upgradesTo": "Modern Armor",
 		"obsoleteTech": "Advanced Materials",
-		"uniques": ["Can move after attacking",
+		"uniques": [
+			"Can move after attacking",
 			"[-25]% Strength <vs cities>",
 			"No defensive terrain bonus",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
-	},	
+	},
 
-	
-	//T3
-	
+	// T3
 	{
 		"name": "Modern Armor",
 		"unitType": "Armor",
@@ -1154,11 +1219,13 @@
 		"requiredTech": "Advanced Materials",
 		"upgradesTo": "Advanced Armor",
 		"obsoleteTech": "Energy Weapons",
-		"uniques": ["Can move after attacking",
+		"uniques": [
+			"Can move after attacking",
 			"[-25]% Strength <vs cities>",
 			"No defensive terrain bonus",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
 	},
@@ -1171,13 +1238,15 @@
 		"range": 3,
 		"cost": 350,
 		"requiredTech": "Rocketry",
-		"uniques": ["[+100]% Strength <vs cities>",
+		"uniques": [
+			"[+100]% Strength <vs cities>",
 			"No defensive terrain bonus",
 			"[-50]% Strength <vs [Helicopter] units>",
 			"[-1] Sight",
 			"May withdraw before melee ([50]%)",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"promotions": ["Artillery"],
 		"hurryCostModifier": 20,
 		"attackSound": "artillery"
@@ -1191,12 +1260,14 @@
 		"rangedStrength": 40,
 		"cost": 325,
 		"requiredTech": "Lasers",
-		"uniques": ["Can move after attacking",
+		"uniques": [
+			"Can move after attacking",
 			"No defensive terrain bonus",
 			"[+150]% Strength <vs [Armor] units>",
 			"May withdraw before melee ([75]%)",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "missile"
 	},
@@ -1210,13 +1281,15 @@
 		"rangedStrength": 25,
 		"cost": 375,
 		"requiredTech": "Lasers",
-		"uniques": ["[100]% chance to intercept air attacks",
+		"uniques": [
+			"[100]% chance to intercept air attacks",
 			"[+300]% Strength <vs [Air] units>",
 			"[+300]% Strength <vs [Helicopter] units>",
 			"No defensive terrain bonus",
 			"May withdraw before melee ([50]%)",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "missile"
 	},
@@ -1227,20 +1300,21 @@
 		"strength": 90,
 		"cost": 425,
 		"requiredTech": "Energy Weapons",
-		/*
-		"upgradesTo": "Giant Death Robot",
-		"obsoleteTech": "Nuclear Fusion",
-		*/
-		"uniques": ["Can move after attacking",
+		// "upgradesTo": "Giant Death Robot",
+		// "obsoleteTech": "Nuclear Fusion",
+		"uniques": [
+			"Can move after attacking",
 			"[-25]% Strength <vs cities>",
 			"No defensive terrain bonus",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],		
-		"promotions": ["Point Defense Laser","Drone Recon"],
+			"Consumes [1] [Oil]"
+		],
+		"promotions": ["Point Defense Laser", "Drone Recon"],
 		"hurryCostModifier": 20,
 		"attackSound": "tankshot"
 	},
-	//helicopters
+
+	// Helicopters
 	{
 		"name": "Helicopter",
 		"unitType": "Helicopter",
@@ -1251,13 +1325,15 @@
 		"cost": 225,
 		"requiredTech": "Gyroscopes",
 		"obsoleteTech": "Lasers",
-		"upgradesTo": "Attack Helicopter",	
-		"uniques": ["[-25]% Strength <vs [Armor] units>",
+		"upgradesTo": "Attack Helicopter",
+		"uniques": [
+			"[-25]% Strength <vs [Armor] units>",
 			"Can move after attacking",
 			"[-25]% Strength <vs cities>",
 			"May withdraw before melee ([100]%)",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"promotions": ["Amphibious"],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
@@ -1271,21 +1347,22 @@
 		"rangedStrength": 50,
 		"cost": 375,
 		"requiredTech": "Lasers",
-		"uniques": ["[33]% chance to intercept air attacks",
+		"uniques": [
+			"[33]% chance to intercept air attacks",
 			"[+1] Sight",
 			"Can move after attacking",
 			"Ranged attacks may be performed over obstacles",
 			"May withdraw before melee ([100]%)",
 			"Only available <in cities with a [Aerospace Facility]>",
 			"[-25]% Strength <vs cities>",
-			"Consumes [1] [Oil]"],
-		"promotions": ["Amphibious","Advanced Weapons","Antitank Missile"],
+			"Consumes [1] [Oil]"
+		],
+		"promotions": ["Amphibious", "Advanced Weapons", "Antitank Missile"],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"
 	},
-	
-	//air
 
+	// Air
 	{
 		"name": "Fighter",
 		"unitType": "Fighter",
@@ -1298,10 +1375,12 @@
 		"upgradesTo": "Jet Fighter",
 		"obsoleteTech": "Robotics",
 		"hurryCostModifier": 20,
-		"uniques": ["[100]% chance to intercept air attacks",
+		"uniques": [
+			"[100]% chance to intercept air attacks",
 			"[+100]% Strength <vs [Bomber] units>",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"attackSound": "machinegun"
 	},
 	{
@@ -1314,12 +1393,14 @@
 		"cost": 185,
 		"requiredTech": "Flight",
 		"upgradesTo": "Strike Drone",
-		"uniques": ["Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+		"uniques": [
+			"Only available <if [Factory] is constructed>",
+			"Consumes [1] [Oil]"
+		],
 		"obsoleteTech": "Lasers",
 		"hurryCostModifier": 20,
 		"attackSound": "bombing"
-	},		
+	},
 
 	{
 		"name": "Strike Drone",
@@ -1331,13 +1412,15 @@
 		"cost": 300,
 		"requiredTech": "Avionics",
 		"hurryCostModifier": 20,
-		"uniques": ["6 tiles in every direction always visible",
+		"uniques": [
+			"6 tiles in every direction always visible",
 			"Only available <if [Factory] is constructed>",
 			"Only available <in cities with a [Factory]>",
-			"Consumes [1] [Aluminum]"],
+			"Consumes [1] [Aluminum]"
+		],
 		"promotions": ["Automated"],
 		"attackSound": "jetgun"
-	},	
+	},
 	{
 		"name": "Jet Fighter",
 		"unitType": "Fighter",
@@ -1348,11 +1431,13 @@
 		"cost": 400,
 		"requiredTech": "Avionics",
 		"hurryCostModifier": 20,
-		"uniques": ["[100]% chance to intercept air attacks",
+		"uniques": [
+			"[100]% chance to intercept air attacks",
 			"[+100]% Strength <vs [Bomber] units>",
 			"Only available <if [Aerospace Facility] is constructed>",
 			"Only available <in cities with a [Aerospace Facility]>",
-			"Consumes [1] [Oil]"],	
+			"Consumes [1] [Oil]"
+		],
 		"attackSound": "jetgun"
 	},
 	{
@@ -1365,18 +1450,18 @@
 		"cost": 280,
 		"requiredTech": "Robotics",
 		"hurryCostModifier": 20,
-		"uniques": ["[100]% chance to intercept air attacks",
+		"uniques": [
+			"[100]% chance to intercept air attacks",
 			"[+100]% Strength <vs [Bomber] units>",
 			"Only available <if [Aerospace Facility] is constructed>",
 			"Only available <in cities with a [Aerospace Facility]>",
-			"Consumes [1] [Aluminum]"],
+			"Consumes [1] [Aluminum]"
+		],
 		"promotions": ["Automated"],
 		"attackSound": "jetgun"
-	},	
+	},
 
-	
-	//naval
-	
+	// Naval
 	{
 		"name": "Trimaran",
 		"unitType": "Melee Water",
@@ -1386,8 +1471,7 @@
 		"cost": 50,
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Jet Boat",
-		"uniques": ["Low Tech",
-			"May withdraw before melee ([66]%)"],
+		"uniques": ["Low Tech", "May withdraw before melee ([66]%)"],
 		"attackSound": "nonmetalhit"
 	},
 	{
@@ -1399,10 +1483,12 @@
 		"requiredTech": "Astronomy",
 		"upgradesTo": "Attack Boat",
 		"obsoleteTech": "Steam Power",
-		"uniques": ["Double movement in [Coast]",
+		"uniques": [
+			"Double movement in [Coast]",
 			"May withdraw before melee ([66]%)",
 			"Unable to capture cities",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shipguns"
 	},
@@ -1417,9 +1503,11 @@
 		"requiredTech": "Astronomy",
 		"upgradesTo": "Attack Boat",
 		"obsoleteTech": "Steam Power",
-		"uniques": ["Double movement in [Coast]",
+		"uniques": [
+			"Double movement in [Coast]",
 			"May withdraw before melee ([66]%)",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shipguns"
 	},
@@ -1430,12 +1518,14 @@
 		"strength": 30,
 		"cost": 100,
 		"requiredTech": "Steam Power",
-		"uniques": ["Double movement in [Coast]",
+		"uniques": [
+			"Double movement in [Coast]",
 			"May withdraw before melee ([66]%)",
-			"Unable to capture cities"],
+			"Unable to capture cities"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shipguns"
-	},		
+	},
 	{
 		"name": "Corvette",
 		"uniqueTo": "The Mariners",
@@ -1445,23 +1535,27 @@
 		"strength": 30,
 		"cost": 100,
 		"requiredTech": "Steam Power",
-		"uniques": ["Double movement in [Coast]",
-			"May withdraw before melee ([66]%)"],
+		"uniques": [
+			"Double movement in [Coast]",
+			"May withdraw before melee ([66]%)"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shipguns"
-	},	
+	},
 	{
 		"name": "Jet Boat",
 		"uniqueTo": "The Mariners",
 		"replaces": "Soldier",
-		"unitType":"Melee Water",
+		"unitType": "Melee Water",
 		"strength": 40,
 		"movement": 6,
 		"cost": 120,
 		"requiredTech": "Replaceable Parts",
-		"uniques": ["Personnel",
+		"uniques": [
+			"Personnel",
 			"Double movement in [Coast]",
-			"May withdraw before melee ([66]%)"],
+			"May withdraw before melee ([66]%)"
+		],
 		"hurryCostModifier": 25,
 		"attackSound": "shot"
 	},
@@ -1475,17 +1569,19 @@
 		"interceptRange": 2,
 		"cost": 300,
 		"requiredTech": "Radar",
-		"uniques": ["Can see invisible [Submarine] units",
+		"uniques": [
+			"Can see invisible [Submarine] units",
 			"[50]% chance to intercept air attacks",
 			"[+100]% Strength <vs [Air] units>",
 			"[+100]% Strength <vs [Helicopter] units>",
 			"May withdraw before melee ([66]%)",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shipguns"
 	},
-		{
+	{
 		"name": "Carrier",
 		"unitType": "Aircraft Carrier",
 		"movement": 5,
@@ -1494,9 +1590,11 @@
 		"interceptRange": 2,
 		"cost": 400,
 		"requiredTech": "Radar",
-        "uniques": ["Can carry [2] [Aircraft] units",
+		"uniques": [
+			"Can carry [2] [Aircraft] units",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shipguns"
 	},
@@ -1509,9 +1607,11 @@
 		"range": 3,
 		"cost": 400,
 		"requiredTech": "Ballistics",
-		"uniques": ["[+25]% Strength <vs cities>",
+		"uniques": [
+			"[+25]% Strength <vs cities>",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"promotions": ["Artillery"],
 		"hurryCostModifier": 20,
 		"attackSound": "shipguns"
@@ -1525,10 +1625,12 @@
 		"cost": 300,
 		"upgradesTo": "Nuclear Submarine",
 		"requiredTech": "Gyroscopes",
-		"uniques": ["[+66]% Strength <when attacking>",
+		"uniques": [
+			"[+66]% Strength <when attacking>",
 			"Can only attack [Water] tiles",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "torpedo"
 	},
@@ -1541,54 +1643,60 @@
 		"rangedStrength": 85,
 		"cost": 425,
 		"requiredTech": "Particle Physics",
-		"uniques": ["[+75]% Strength <when attacking>",
+		"uniques": [
+			"[+75]% Strength <when attacking>",
 			"Can only attack [Water] tiles",
 			"[+1] Sight",
 			"Can carry [2] [Missile] units",
 			"Only available <if [Factory] is constructed>",
-			"Consumes [1] [Uranium]"],
+			"Consumes [1] [Uranium]"
+		],
 		"attackSound": "torpedo"
 	},
 
-	// religious
-
+	// Religious
 	{
 		"name": "Philosopher",
 		"unitType": "Civilian",
-		"uniques": ["Can [Spread Religion] [2] times",
+		"uniques": [
+			"Can [Spread Religion] [2] times",
 			"May enter foreign tiles without open borders",
-			"Can be purchased with [Faith] [in all cities in which the majority religion is a major religion]", 
+			"Can be purchased with [Faith] [in all cities in which the majority religion is a major religion]",
 			"[-1] Sight",
 			"Unbuildable",
 			"Religious Unit",
-			"Hidden when religion is disabled"],
+			"Hidden when religion is disabled"
+		],
 		"movement": 4,
 		"religiousStrength": 1000
 	},
 	{
 		"name": "Censor",
 		"unitType": "Civilian",
-		"uniques": ["Prevents spreading of religion to the city it is next to",
+		"uniques": [
+			"Prevents spreading of religion to the city it is next to",
 			"Can [Remove Foreign religions from your own cities] [2] times",
 			"Can be purchased with [Faith] [in all cities in which the majority religion is an enhanced religion]",
 			"[+1] Sight",
 			"Hidden when religion is disabled",
 			"Unbuildable",
-			"Religious Unit"],
+			"Religious Unit"
+		],
 		"movement": 3
 	},
 
-	
-	/* Great people */
+	// Great people
 	{
 		"name": "Great Administrator",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age",
+		"uniques": [
+			"Can start an [8]-turn golden age",
 			"Can construct [Settlement]",
 			"Can construct [Citadel]",
 			"Great Person - [Culture]",
 			"Unbuildable",
-			"Uncapturable"],
+			"Uncapturable"
+		],
 		"movement": 2
 	},
 	{
@@ -1596,51 +1704,59 @@
 		"uniqueTo": "Cult of Ignis",
 		"replaces": "Great Administrator",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age",
+		"uniques": [
+			"Can start an [8]-turn golden age",
 			"Can construct [Oracle]",
 			"Great Person - [Culture]",
 			"Uncapturable",
-			"Unbuildable"],
+			"Unbuildable"
+		],
 		"movement": 2
-	},		
+	},
 	{
 		"name": "Great Sage",
 		"unitType": "Civilian",
-		"uniques": ["Can construct [Seminary] if it hasn't used other actions yet", 
+		"uniques": [
+			"Can construct [Seminary] if it hasn't used other actions yet",
 			"Can [Spread Religion] [4] times",
 			"Removes other religions when spreading religion",
 			"May found a religion",
-			"May enhance a religion", 
+			"May enhance a religion",
 			"May enter foreign tiles without open borders",
 			"[-1] Sight",
-			"Great Person - [Faith]", 
+			"Great Person - [Faith]",
 			"Unbuildable",
 			"Uncapturable",
 			"Religious Unit",
-			"Hidden when religion is disabled", 
-			"Takes your religion over the one in their birth city"],
+			"Hidden when religion is disabled",
+			"Takes your religion over the one in their birth city"
+		],
 		"movement": 2,
 		"religiousStrength": 1000
 	},
 	{
 		"name": "Great Scientist",
 		"unitType": "Civilian",
-		"uniques": ["Can hurry technology research",
+		"uniques": [
+			"Can hurry technology research",
 			"Can construct [Academy]",
 			"Great Person - [Science]",
 			"Unbuildable",
-			"Uncapturable"],
+			"Uncapturable"
+		],
 		"movement": 2
 	},
 	{
 		"name": "Great Merchant",
 		"unitType": "Civilian",
-		"uniques": ["Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence",
+		"uniques": [
+			"Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence",
 			"Can start an [8]-turn golden age",
 			"Can construct [Settlement]",
 			"Great Person - [Gold]",
 			"Unbuildable",
-			"Uncapturable"],
+			"Uncapturable"
+		],
 		"movement": 2
 	},
 	{
@@ -1648,13 +1764,15 @@
 		"uniqueTo": "Deadrock Clan",
 		"replaces": "Great Merchant",
 		"unitType": "Civilian",
-		"uniques": ["Invisible to non-adjacent units",
+		"uniques": [
+			"Invisible to non-adjacent units",
 			"Can undertake a trade mission with City-State, giving a large sum of gold and [40] Influence",
 			"Can start an [8]-turn golden age",
 			"Can construct [Narcotics farm]",
 			"Great Person - [Gold]",
 			"Unbuildable",
-			"Uncapturable"],
+			"Uncapturable"
+		],
 		"movement": 2
 	},
 	{
@@ -1662,66 +1780,76 @@
 		"uniqueTo": "Crimson Legion",
 		"replaces": "Great Merchant",
 		"unitType": "Civilian",
-		"uniques": ["Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence",
+		"uniques": [
+			"Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence",
 			"Can start an [8]-turn golden age",
 			"Can construct [Prison farm]",
 			"Great Person - [Gold]",
 			"Unbuildable",
-			"Uncapturable"],
+			"Uncapturable"
+		],
 		"movement": 2
 	},
 	{
 		"name": "Great Engineer",
 		"unitType": "Civilian",
-		"uniques": ["Can speed up construction of a building",
+		"uniques": [
+			"Can speed up construction of a building",
 			"Can construct [Manufactory]",
 			"Great Person - [Production]",
 			"Unbuildable",
-			"Uncapturable"],
+			"Uncapturable"
+		],
 		"movement": 2
-	},	
+	},
 	{
 		"name": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age",
+		"uniques": [
+			"Can start an [8]-turn golden age",
 			"Bonus for units in 2 tile radius 15%",
 			"Can construct [Citadel]",
 			"Great Person - [War]",
 			"Unbuildable",
-			"Uncapturable"],
+			"Uncapturable"
+		],
 		"movement": 2
-	},		
+	},
 	{
 		"name": "Gangboss",
 		"uniqueTo": "Deadrock Clan",
 		"replaces": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can build [Land] improvements on tiles",
+		"uniques": [
+			"Can build [Land] improvements on tiles",
 			"Can start an [8]-turn golden age",
 			"Bonus for units in 2 tile radius 15%",
 			"Can construct [Prison farm]",
 			"Great Person - [War]",
 			"Unbuildable",
-			"Uncapturable"],
+			"Uncapturable"
+		],
 		"movement": 2
-	},		
+	},
 	{
 		"name": "Bugler",
 		"uniqueTo": "Cult of Ignis",
 		"replaces": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age",
+		"uniques": [
+			"Can start an [8]-turn golden age",
 			"Bonus for units in 2 tile radius 15%",
 			"All adjacent units heal [+15] HP when healing",
 			"[+15] HP when healing",
 			"Can construct [Outpost]",
 			"Great Person - [War]",
 			"Uncapturable",
-			"Unbuildable"],
+			"Unbuildable"
+		],
 		"movement": 5
 	},
-	
-	//non player UNIQUES
+
+	// Non-player uniques
 	{
 		"name": "Biker",
 		"unitType": "Mounted",
@@ -1733,16 +1861,18 @@
 		"cost": 55,
 		"requiredTech": "Iron Working",
 		"upgradesTo": "Armored Car",
-		"obsoleteTech": "Replaceable Parts",		
-		"uniques": ["Personnel",
+		"obsoleteTech": "Replaceable Parts",
+		"uniques": [
+			"Personnel",
 			"[+50]% Strength <vs [Low Tech] units>",
 			"[-25]% Strength <vs cities>",
 			"No defensive terrain bonus",
-			"Can move after attacking"],
-		"promotions": ["Forage","Raider","Skirmish","March"],
+			"Can move after attacking"
+		],
+		"promotions": ["Forage", "Raider", "Skirmish", "March"],
 		"hurryCostModifier": 20,
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Bandit",
 		"unitType": "Scrapper",
@@ -1753,9 +1883,9 @@
 		"strength": 20,
 		"cost": 20,
 		"obsoleteTech": "Engineering",
-		"upgradesTo": "Soldier",			
-		"uniques": ["Low Tech"],		
-		"promotions": ["Forage","Raider"],
+		"upgradesTo": "Soldier",
+		"uniques": ["Low Tech"],
+		"promotions": ["Forage", "Raider"],
 		"attackSound": "nonmetalhit"
 	},
 	{
@@ -1769,12 +1899,11 @@
 		"cost": 50,
 		"requiredTech": "Iron Working",
 		"obsoleteTech": "Rifling",
-		"upgradesTo": "Soldier",		
-		"uniques": ["Personnel",
-			"[-40]% Strength <vs cities>"],
-		"promotions": ["Forage","Raider"],
+		"upgradesTo": "Soldier",
+		"uniques": ["Personnel", "[-40]% Strength <vs cities>"],
+		"promotions": ["Forage", "Raider"],
 		"attackSound": "shot"
-	},	
+	},
 	{
 		"name": "Looter",
 		"unitType": "Shooter",
@@ -1787,12 +1916,11 @@
 		"cost": 40,
 		"hurryCostModifier": 20,
 		"obsoleteTech": "Rifling",
-		"upgradesTo": "Rifleman",	
-		"uniques": ["Low Tech",
-			"[+33]% Strength <vs [Low Tech] units>"],
-		"promotions": ["Skirmish","Raider"],
+		"upgradesTo": "Rifleman",
+		"uniques": ["Low Tech", "[+33]% Strength <vs [Low Tech] units>"],
+		"promotions": ["Skirmish", "Raider"],
 		"attackSound": "arrow"
-	},		
+	},
 	{
 		"name": "Marauder",
 		"unitType": "Shooter",
@@ -1806,12 +1934,11 @@
 		"requiredTech": "Iron Working",
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Rifleman",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
-			"[-33]% Strength <vs cities>"],
+		"hurryCostModifier": 20,
+		"uniques": ["Personnel", "[-33]% Strength <vs cities>"],
 		"promotions": ["Raider"],
 		"attackSound": "shot"
-	},		
+	},
 	{
 		"name": "Rebel",
 		"unitType": "Scrapper",
@@ -1821,14 +1948,20 @@
 		"movement": 2,
 		"strength": 40,
 		"cost": 120,
-		"requiredTech":  "Rifling",
+		"requiredTech": "Rifling",
 		"obsoleteTech": "Combined Arms",
-		"upgradesTo": "Infantry",		
-		"uniques": ["Personnel",
-			"[+100]% Strength <vs cities>"],
-		"promotions": ["Forage","Raider","Entrench","Guerilla Warfare I","Urban Warfare I","Ambush"],
+		"upgradesTo": "Infantry",
+		"uniques": ["Personnel", "[+100]% Strength <vs cities>"],
+		"promotions": [
+			"Forage",
+			"Raider",
+			"Entrench",
+			"Guerilla Warfare I",
+			"Urban Warfare I",
+			"Ambush"
+		],
 		"attackSound": "shot"
-	},	
+	},
 	{
 		"name": "Irregular",
 		"unitType": "Shooter",
@@ -1842,12 +1975,17 @@
 		"requiredTech": "Rifling",
 		"obsoleteTech": "Combined Arms",
 		"upgradesTo": "NBC Marksman",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
-			"[+100]% Strength <vs cities>"],
-		"promotions": ["Skirmish","Raider","Entrench","Guerilla Warfare I","Urban Warfare I"],
+		"hurryCostModifier": 20,
+		"uniques": ["Personnel", "[+100]% Strength <vs cities>"],
+		"promotions": [
+			"Skirmish",
+			"Raider",
+			"Entrench",
+			"Guerilla Warfare I",
+			"Urban Warfare I"
+		],
 		"attackSound": "shot"
-	},	
+	},
 	{
 		"name": "Insurgent",
 		"unitType": "Scrapper",
@@ -1858,10 +1996,17 @@
 		"strength": 45,
 		"cost": 225,
 		"requiredTech": "Combined Arms",
-		"hurryCostModifier": 20,		
-		"uniques": ["Personnel",
-			"[+100]% Strength <vs cities>"],
-		"promotions": ["Skirmish","Raider","Entrench","Forage","Guerilla Warfare I","Urban Warfare I","March"],
+		"hurryCostModifier": 20,
+		"uniques": ["Personnel", "[+100]% Strength <vs cities>"],
+		"promotions": [
+			"Skirmish",
+			"Raider",
+			"Entrench",
+			"Forage",
+			"Guerilla Warfare I",
+			"Urban Warfare I",
+			"March"
+		],
 		"attackSound": "machinegun"
 	},
 	{
@@ -1876,14 +2021,24 @@
 		"cost": 225,
 		"requiredTech": "Combined Arms",
 		"hurryCostModifier": 20,
-		"uniques": ["Personnel",
+		"uniques": [
+			"Personnel",
 			"[+100]% Strength <vs cities>",
-			"[-20]% Strength <vs [Armor] units>"],
-		"promotions": ["Skirmish","Raider","Entrench","Extended Range","Guerilla Warfare I","Urban Warfare I","Precision"],		
+			"[-20]% Strength <vs [Armor] units>"
+		],
+		"promotions": [
+			"Skirmish",
+			"Raider",
+			"Entrench",
+			"Extended Range",
+			"Guerilla Warfare I",
+			"Urban Warfare I",
+			"Precision"
+		],
 		"attackSound": "shot"
-	},			
+	},
 
-	//CITY STATE UNITS
+	// City-state uniques
 	{
 		"name": "Howitzer",
 		"unitType": "Siege",
@@ -1896,16 +2051,18 @@
 		"cost": 55,
 		"requiredTech": "The Wheel",
 		"upgradesTo": "Rocket Artillery",
-		"uniques": ["[+100]% Strength <vs cities>",
+		"uniques": [
+			"[+100]% Strength <vs cities>",
 			"No defensive terrain bonus",
 			"[-50]% Strength <vs [Helicopter] units>",
 			"Must set up to ranged attack",
 			"[-1] Sight",
-			"Only available <if [Factory] is constructed>"],
+			"Only available <if [Factory] is constructed>"
+		],
 		"promotions": ["Artillery"],
 		"hurryCostModifier": 20,
 		"attackSound": "artillery"
-	},		
+	},
 	{
 		"name": "Ancient Armor",
 		"unitType": "Armor",
@@ -1916,10 +2073,12 @@
 		"cost": 200,
 		"requiredTech": "The Wheel",
 		"upgradesTo": "Modern Armor",
-		"uniques": ["Can move after attacking",
+		"uniques": [
+			"Can move after attacking",
 			"No defensive terrain bonus",
 			"Only available <if [Alma Tank Depot] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"
 	},
@@ -1934,16 +2093,18 @@
 		"rangedStrength": 50,
 		"cost": 200,
 		"requiredTech": "Steel",
-		"upgradesTo": "Helicopter",	
-		"uniques": ["[-25]% Strength <vs [Armor] units>",
+		"upgradesTo": "Helicopter",
+		"uniques": [
+			"[-25]% Strength <vs [Armor] units>",
 			"Can move after attacking",
 			"May withdraw before melee ([100]%)",
 			"Only available <if [Alma Air Base] is constructed>",
-			"Consumes [1] [Oil]"],
+			"Consumes [1] [Oil]"
+		],
 		"promotions": ["Amphibious"],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Salvaged Bomber",
 		"unitType": "Bomber",
@@ -1956,12 +2117,14 @@
 		"cost": 185,
 		"requiredTech": "The Wheel",
 		"upgradesTo": "Bomber",
-		"uniques": ["Only available <if [Alma Air Base] is constructed>",
-			"Consumes [1] [Oil]"],
+		"uniques": [
+			"Only available <if [Alma Air Base] is constructed>",
+			"Consumes [1] [Oil]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"
 	},
-	
+
 	{
 		"name": "Arroyo Defender",
 		"unitType": "Scrapper",
@@ -1971,13 +2134,15 @@
 		"strength": 24,
 		"cost": 50,
 		"requiredTech": "Steel",
-		"upgradesTo": "Infantry",				
-		"uniques": ["Low Tech",
+		"upgradesTo": "Infantry",
+		"uniques": [
+			"Low Tech",
 			"[+50]% Strength <vs [Low Tech] units>",
-			"[+50]% Strength <vs [Mounted] units>"],		
+			"[+50]% Strength <vs [Mounted] units>"
+		],
 		"promotions": ["Ambush"],
 		"attackSound": "nonmetalhit"
-	},	
+	},
 	{
 		"name": "Arroyo Greatbow",
 		"unitType": "Shooter",
@@ -1990,12 +2155,11 @@
 		"cost": 60,
 		"hurryCostModifier": 20,
 		"requiredTech": "Steel",
-		"upgradesTo": "Marksman", 		
-		"uniques": ["Low Tech",
-			"[+33]% Strength <vs [Low Tech] units>"],
+		"upgradesTo": "Marksman",
+		"uniques": ["Low Tech", "[+33]% Strength <vs [Low Tech] units>"],
 		"promotions": ["Skirmish"],
 		"attackSound": "arrow"
-	},		
+	},
 	{
 		"name": "Arroyo Machine Gun",
 		"unitType": "Siege",
@@ -2009,16 +2173,15 @@
 		"requiredTech": "Rifling",
 		"hurryCostModifier": 20,
 		"requiredResource": "Weapons",
-		"uniques": ["Must set up to ranged attack",
-			"[-33]% Strength <vs [Armor] units>"
-			,"[-33]% Strength <vs cities>",
-			"Personnel"],
+		"uniques": [
+			"Must set up to ranged attack",
+			"[-33]% Strength <vs [Armor] units>",
+			"[-33]% Strength <vs cities>",
+			"Personnel"
+		],
 		"attackSound": "machinegun"
-	},	
-	
-	
-	
-	
+	},
+
 	{
 		"name": "Ghost Defender",
 		"unitType": "Scrapper",
@@ -2028,13 +2191,15 @@
 		"strength": 24,
 		"cost": 50,
 		"requiredTech": "Steel",
-		"upgradesTo": "Infantry",				
-		"uniques": ["Low Tech",
+		"upgradesTo": "Infantry",
+		"uniques": [
+			"Low Tech",
 			"[+50]% Strength <vs [Low Tech] units>",
-			"[+50]% Strength <vs [Mounted] units>"],		
+			"[+50]% Strength <vs [Mounted] units>"
+		],
 		"promotions": ["Ambush"],
 		"attackSound": "nonmetalhit"
-	},	
+	},
 	{
 		"name": "Ghost Greatbow",
 		"unitType": "Shooter",
@@ -2047,13 +2212,12 @@
 		"cost": 60,
 		"hurryCostModifier": 20,
 		"requiredTech": "Steel",
-		"upgradesTo": "Marksman", 			
-		"uniques": ["Low Tech",
-			"[+33]% Strength <vs [Low Tech] units>"],
+		"upgradesTo": "Marksman",
+		"uniques": ["Low Tech", "[+33]% Strength <vs [Low Tech] units>"],
 		"promotions": ["Skirmish"],
 		"attackSound": "arrow"
-	},		
-	
+	},
+
 	{
 		"name": "Ghost Machine Gun",
 		"unitType": "Siege",
@@ -2067,12 +2231,14 @@
 		"requiredTech": "Rifling",
 		"hurryCostModifier": 20,
 		"requiredResource": "Weapons",
-		"uniques": ["Must set up to ranged attack",
+		"uniques": [
+			"Must set up to ranged attack",
 			"[-33]% Strength <vs [Armor] units>",
 			"[-33]% Strength <vs cities>",
-			"Personnel"],
+			"Personnel"
+		],
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Hub Auxiliary",
 		"uniqueTo": "The Hub",
@@ -2083,15 +2249,17 @@
 		"cost": 20,
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Militia",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
-			"[+50]% Strength <vs [Mounted] units>"],
+			"[+50]% Strength <vs [Mounted] units>"
+		],
 		"attackSound": "metalhit"
 	},
 	{
 		"name": "Hub Militia",
-		"uniqueTo":"The Hub",
+		"uniqueTo": "The Hub",
 		"replaces": "Militia",
 		"unitType": "Scrapper",
 		"interceptRange": 1,
@@ -2100,11 +2268,11 @@
 		"cost": 55,
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
-		"upgradesTo": "Soldier",		
+		"upgradesTo": "Soldier",
 		"uniques": ["Personnel"],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
-	},	
+	},
 	{
 		"name": "Hub Gunman",
 		"uniqueTo": "The Hub",
@@ -2118,13 +2286,13 @@
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Rifleman",
-		"hurryCostModifier": 20,		
+		"hurryCostModifier": 20,
 		"uniques": ["Personnel"],
 		"attackSound": "shot"
-	},	
+	},
 	{
 		"name": "Hub Crossbowman",
-		"uniqueTo":"The Hub",
+		"uniqueTo": "The Hub",
 		"replaces": "Crossbowman",
 		"unitType": "Shooter",
 		"range": 1,
@@ -2136,15 +2304,16 @@
 		"requiredTech": "Iron Working",
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Gunman",
-		"uniques": ["Low Tech",
+		"uniques": [
+			"Low Tech",
 			"Can build [Road] improvements on tiles",
 			"Can build [Fort] improvements on tiles",
-			"[+33]% Strength <vs [Low Tech] units>"],
+			"[+33]% Strength <vs [Low Tech] units>"
+		],
 		"attackSound": "arrow"
-	},		
-	
-	//fake restriction units
-	
+	},
+
+	// Fake restriction units
 	{
 		"name": "Ignis Can't Build Spearman",
 		"unitType": "Scrapper",
@@ -2153,9 +2322,9 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"],
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"],
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Ignis Can't Build Archer",
 		"unitType": "Scrapper",
@@ -2164,9 +2333,9 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"],
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"],
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Clan Can't Build Horseman",
 		"unitType": "Scrapper",
@@ -2175,9 +2344,9 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"],
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"],
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Clan Can't Build Skirmisher",
 		"unitType": "Scrapper",
@@ -2186,9 +2355,9 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"],
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"],
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Patriots Can't Build Spearman",
 		"unitType": "Scrapper",
@@ -2197,9 +2366,9 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"],
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"],
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Patriots Can't Build Archer",
 		"unitType": "Scrapper",
@@ -2208,9 +2377,9 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"],
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"],
 		"attackSound": "metalhit"
-	},		
+	},
 	{
 		"name": "Patriots Can't Build Horseman",
 		"unitType": "Scrapper",
@@ -2219,9 +2388,9 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"],
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"],
 		"attackSound": "metalhit"
-	},	
+	},
 	{
 		"name": "Patriots Can't Build Skirmisher",
 		"unitType": "Scrapper",
@@ -2230,10 +2399,9 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"],
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"],
 		"attackSound": "metalhit"
-	},	
-
+	},
 
 	{
 		"name": "Arroyo Can't Build Cavalry",
@@ -2244,8 +2412,8 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"]
-	},	
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"]
+	},
 	{
 		"name": "Arroyo Can't Build Car",
 		"unitType": "Scrapper",
@@ -2255,8 +2423,8 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"]
-	},	
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"]
+	},
 	{
 		"name": "Arroyo Can't Build Light Cavalry",
 		"unitType": "Scrapper",
@@ -2266,7 +2434,7 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"]
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"]
 	},
 
 	{
@@ -2278,9 +2446,9 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"]
-	},	
-	
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"]
+	},
+
 	{
 		"name": "Ghost Can't Build Light Cavalry",
 		"unitType": "Scrapper",
@@ -2290,8 +2458,8 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"]
-	},		
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"]
+	},
 	{
 		"name": "Ghost Can't Build Car",
 		"unitType": "Scrapper",
@@ -2301,6 +2469,6 @@
 		"strength": 1,
 		"cost": 1,
 		"obsoleteTech": "The Wheel",
-		"uniques": ["Unbuildable","Will not be displayed in Civilopedia"]
+		"uniques": ["Unbuildable", "Will not be displayed in Civilopedia"]
 	}
 ]


### PR DESCRIPTION
- Fixed applyHumidityAndTemperature error
  - Previously, no terrain was assigned to -0.4 ~ -0.3 temperature and 0.0 ~ 0.2 humidity.
  - This would occasionally cause errors at the start of a new game such as `applyHumidityAndTemperature: No terrain found for temperature: -0.32439179283871306, humidity: 0.17345136836823877`.
  - 8157629385b57142755141f813dbb3771918273c assigns Badlands to the said spot, just like the vanilla ruleset.
- Updated embarkation uniques
  - `"<starting from the [Decivilized era]>"` seems redundant since it is the very first era.
  - `"Enables embarked units to enter ocean tiles"` is deprecated as of 3.19.13; replacing it with `"Enables [Embarked] units to enter ocean tiles"`
- Settlements now also benefit from Rubble tiles
  - This closes #18.
  - Although not implemented in this PR, I do still like the idea of settlements gaining `"[+1 Culture] for each adjacent [City center]"` and would be grateful if you consider it.
