### PR TITLE
Increase city strength

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DeCiv-Redux
-DeCiv Redux 4.1.0
-3 March 2012
+
+DeCiv Redux 4.1.0<br>
+3 March 2021
 
 DeCiv, made by [9kgsofrice](https://github.com/9kgsofrice/DeCiv/), brought back from the dead by SpacedOutChicken
 

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -5,7 +5,7 @@
 		"isNationalWonder": true,
 		"food": 2,
 		"production": 3,
-		"cityStrength": 2,
+		"cityStrength": 5,
 		"cityHealth": 50,
 		"science": 3,
 		"gold": 1,
@@ -2540,7 +2540,7 @@
 		"uniques": ["[+50]% Golden Age length", "Provides [1] [Power]"]
 	},
 	{
-		"name": "Encylopedia",
+		"name": "Encyclopedia",
 		"uniqueTo": "The Archive",
 		"replaces": "Monument",
 		"cost": 1,

--- a/jsons/ModOptions.json
+++ b/jsons/ModOptions.json
@@ -1,9 +1,13 @@
 {
     "isBaseRuleset": true,
-    "uniques": ["Can convert gold to science with sliders",
+    "uniques": [
+        "Can convert gold to science with sliders",
         "Allow City States to spawn with additional units",
-        "Can trade civilization introductions for [100] Gold"],
+        "Can trade civilization introductions for [100] Gold"
+    ],
     "constants": {
-        "maxXPfromBarbarians": 100
-    } 
+        "cityStrengthBase": 20.0, // Default was 8.0
+        "cityStrengthPerPop": 0.5, // Default was 0.4
+        "maxXPfromBarbarians": 100 // Default was 30
+    }
 }

--- a/jsons/Terrains.json
+++ b/jsons/Terrains.json
@@ -268,16 +268,23 @@
 		"defenceBonus": -0.3
 	},
 	{
+		/*
+		TODO:
+		- Legacy code for compatibility
+		- Should be replaced with Swamp
+		- See also: https://github.com/SpacedOutChicken/DeCiv-Redux/issues/21
+		*/
 		"name": "Flood plains",
 		"type": "TerrainFeature",
 		"food": 1,
 		"movementCost": 1,
 		"defenceBonus": -0.1,
-		"occursOn": ["Desert", "Plains", "Grassland"],
+		// "occursOn": ["Desert", "Plains", "Grassland"],
 		"uniques": [
 			"Considered [Desirable] when determining start locations",
 			"Considered [Food] when determining start locations",
-			"Always Fertility [5] for Map Generation"
+			"Always Fertility [5] for Map Generation",
+			"Will not be displayed in Civilopedia"
 		]
 	},
 	{

--- a/jsons/Terrains.json
+++ b/jsons/Terrains.json
@@ -268,12 +268,8 @@
 		"defenceBonus": -0.3
 	},
 	{
-		/*
-		TODO:
-		- Legacy code for compatibility
-		- Should be replaced with Swamp
-		- See also: https://github.com/SpacedOutChicken/DeCiv-Redux/issues/21
-		*/
+		// Replaced with swamp; This is a legacy code for compatibility.
+		// See also: https://github.com/SpacedOutChicken/DeCiv-Redux/issues/21
 		"name": "Flood plains",
 		"type": "TerrainFeature",
 		"food": 1,
@@ -293,9 +289,7 @@
 		"movementCost": 1,
 		"defenceBonus": -0.1,
 		"occursOn": ["Desert", "Plains", "Grassland"],
-		"uniques": [
-			"Always Fertility [5] for Map Generation"
-		]
+		"uniques": ["Always Fertility [5] for Map Generation"]
 	},
 	{
 		"name": "Sunken Ruins",

--- a/jsons/TileSets/FantasyHex.json
+++ b/jsons/TileSets/FantasyHex.json
@@ -1,13 +1,14 @@
 {
     "useColorAsBaseTerrain": "false",
     "ruleVariants": {
-        // Hill farm
+        // Farm
+        "Snow+Farm": ["Snow","Farm"],
         "Grassland+Hill+Farm": ["Grassland","Farm","Hill"],
         "Plains+Hill+Farm": ["Plains","Farm","Hill"],
         "Desert+Hill+Farm": ["Desert","Farm","Hill"],
         "Tundra+Hill+Farm": ["Tundra","Farm","Hill"],
         "Snow+Hill+Farm": ["Snow","Farm","Hill"],
-		
+
         //Special forest and jungle
         "Grassland+Forest": ["Grassland","GrasslandForest"],
         "Grassland+Jungle": ["Grassland","Jungle"],
@@ -27,22 +28,22 @@
         "Snow+Hill+Jungle": ["Snow","Hill","SnowJungle"],
 
         //Snow improvements for Tundra and Snow
-            //TODO hill and forest variants + new images for Landmark, etc
-            "Tundra+Barbarian encampment": ["Tundra","Barbarian encampment-Snow"],
-            "Tundra+Academy": ["Tundra","Academy"],
-            "Tundra+Citadel": ["Tundra","Citadel"],
-            "Tundra+Ancient ruins": ["Tundra","Ancient ruins-Snow"],
-            "Snow+Barbarian encampment": ["Snow","Barbarian encampment-Snow"],
-            "Snow+Academy": ["Snow","Academy"],
-            "Snow+Citadel": ["Snow","Citadel"],
-            "Snow+Ancient ruins": ["Snow","Ancient ruins-Snow"],
+        //TODO hill and forest variants + new images for Landmark, etc
+        "Tundra+Barbarian encampment": ["Tundra","Barbarian encampment-Snow"],
+        "Tundra+Academy": ["Tundra","Academy"],
+        "Tundra+Citadel": ["Tundra","Citadel"],
+        "Tundra+Ancient ruins": ["Tundra","Ancient ruins-Snow"],
+        "Snow+Barbarian encampment": ["Snow","Barbarian encampment-Snow"],
+        "Snow+Academy": ["Snow","Academy"],
+        "Snow+Citadel": ["Snow","Citadel"],
+        "Snow+Ancient ruins": ["Snow","Ancient ruins-Snow"],
 
         //Sand improvements for Desert
 
         //Jungle improvements for Jungle
 
         //resources behind forest and jungle
-            //TODO all the resources...
+        //TODO all the resources...
         //Grassland
         "Grassland+Jungle+Oil": ["Grassland","Oil","Jungle"],
         "Grassland+Forest+Horses": ["Grassland","Horses","GrasslandForest"],
@@ -158,7 +159,7 @@
         "Tundra+Hill+Jungle+Gems": ["Tundra","Hill","Gems","TundraJungle"],
         "Tundra+Hill+Forest+Silver": ["Tundra","Hill","Silver","TundraHillForest"],
         "Tundra+Hill+Forest+Gems": ["Tundra","Hill","Gems","TundraHillForest"],
-		
+
         "Desert+Wheat+Farm": ["Desert","Farm","Wheat"],
         "Desert+Farm": ["Desert","Farm"],
         "Desert+Flood plains+Wheat+Farm": ["Desert","Flood plains","Farm","Wheat"],
@@ -191,13 +192,12 @@
         "Desert+Hill+Forest+Silver": ["Desert","Hill","Silver","DesertHillForest"],
         "Desert+Hill+Forest+Gems": ["Desert","Hill","Gems","DesertHillForest"],
 
-		
         "Grassland+Forest+Ancient ruins": ["Grassland", "GrasslandForest","Ancient ruins"],
         "Grassland+Cattle+Ancient ruins": ["Grassland","Ancient ruins","Cattle"],
         "Grassland+Sheep+Ancient ruins": ["Grassland","Ancient ruins","Sheep"],
         "Coast+Oil+Oil well": ["Coast","Offshore Platform"],
 
-//Deciv Tile Improvements
+        //Deciv Tile Improvements
         //Salvage site
         "Grassland+Salvage site+Scrap": ["Grassland","Scrap","Salvage site"],
         "Grassland+Forest+Salvage site+Scrap": ["Grassland","Scrap","GrasslandForest","Salvage site"],
@@ -313,6 +313,5 @@
 
         //Furs
         "Grassland+Forest+Furs+Camp": ["Grassland","GrasslandForest","Camp+Furs"]
-
     }
 }


### PR DESCRIPTION
- **Increased city strength**
  - Pseudocloses the first part of https://github.com/SpacedOutChicken/DeCiv-Redux/issues/31#issuecomment-1064094366.
  - In short, Initial city strength is now on par with that of a Spearman.
    - Base city strength increased from 8 to 20.
    - City strength per pop increased from 0.4 to 0.5.
    - Bomb Shelter now gives 5 city strength instead of 2.
  - Made early-game rushes much harder while still allowing aggressive late games.
  - Also fixed a typo in Buildings.json.
- **Hid Flood plains**
  - Closes #21.
  - Flood plains are now hidden from Civilopedia since they will not spawn.
- **Fixed snow farm using vanilla tileset**
  - Snow farm *without* hills now uses DeCiv's tileset.
  - Also fixed my mistake in 6a0906f16a20fab48011c8f288714f27a65f11df:<br>I forgot that multiple trailing spaces in markdown is a line break...

Related: #35