### PR TITLE
Changes to Policy Branches

### DIFF
--- a/jsons/Difficulties.json
+++ b/jsons/Difficulties.json
@@ -13,7 +13,7 @@
 		"barbarianBonus": 0.75,
 		"barbarianSpawnDelay": 8,
 		"playerBonusStartingUnits": ["Civilian Convoy", "Scout"],
-		"aiCityGrowthModifier": 1.6, 
+		"aiCityGrowthModifier": 1.6,
 		"aiUnitCostModifier": 1.75,
 		"aiBuildingCostModifier": 1.6,
 		"aiWonderCostModifier": 1.6,
@@ -22,7 +22,11 @@
 		"aiUnitSupplyModifier": 0,
 		"aiFreeTechs": [],
 		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 1,
 		"aisExchangeTechs": false,
 		"turnBarbariansCanEnterPlayerTiles": 10000,
@@ -47,7 +51,11 @@
 		"aiUnitMaintenanceModifier": 0.75,
 		"aiFreeTechs": [],
 		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 1,
 		"aisExchangeTechs": true,
 		"turnBarbariansCanEnterPlayerTiles": 60,
@@ -72,7 +80,11 @@
 		"aiUnitMaintenanceModifier": 0.5,
 		"aiFreeTechs": [],
 		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 1,
 		"aisExchangeTechs": true,
 		"turnBarbariansCanEnterPlayerTiles": 40,
@@ -97,7 +109,11 @@
 		"aiUnitMaintenanceModifier": 0.35,
 		"aiFreeTechs": [],
 		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 1,
 		"aisExchangeTechs": true,
 		"turnBarbariansCanEnterPlayerTiles": 0,
@@ -122,7 +138,11 @@
 		"aiUnitMaintenanceModifier": 0.25,
 		"aiFreeTechs": ["Redomestication", "Iron Working"],
 		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 0.75,
 		"aisExchangeTechs": true,
 		"turnBarbariansCanEnterPlayerTiles": 0,
@@ -143,11 +163,15 @@
 		"aiUnitCostModifier": 0.4,
 		"aiBuildingCostModifier": 1,
 		"aiWonderCostModifier": 1,
-		"aiBuildingMaintenanceModifier": 0.20,
-		"aiUnitMaintenanceModifier": 0.20,
+		"aiBuildingMaintenanceModifier": 0.2,
+		"aiUnitMaintenanceModifier": 0.2,
 		"aiFreeTechs": ["Redomestication", "Iron Working"],
 		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 0.7,
 		"aisExchangeTechs": true,
 		"turnBarbariansCanEnterPlayerTiles": 0,
@@ -170,9 +194,18 @@
 		"aiWonderCostModifier": 1,
 		"aiBuildingMaintenanceModifier": 0.15,
 		"aiUnitMaintenanceModifier": 0.15,
-		"aiFreeTechs": ["Secrets of the Past", "Construction", "Redomestication", "Iron Working"],
+		"aiFreeTechs": [
+			"Secrets of the Past",
+			"Construction",
+			"Redomestication",
+			"Iron Working"
+		],
 		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Scout", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 0.6,
 		"aisExchangeTechs": true,
 		"turnBarbariansCanEnterPlayerTiles": 0,
@@ -195,9 +228,24 @@
 		"aiWonderCostModifier": 1,
 		"aiBuildingMaintenanceModifier": 0.15,
 		"aiUnitMaintenanceModifier": 0.15,
-		"aiFreeTechs": ["Secrets of the Past", "Construction", "Redomestication", "Iron Working"],
-		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Civilian Convoy", "Scout", "Scout", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiFreeTechs": [
+			"Secrets of the Past",
+			"Construction",
+			"Redomestication",
+			"Iron Working"
+		],
+		"aiMajorCivBonusStartingUnits": [
+			"Civilian Convoy",
+			"Civilian Convoy",
+			"Scout",
+			"Scout",
+			"Scout"
+		],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 0.55,
 		"aisExchangeTechs": true,
 		"turnBarbariansCanEnterPlayerTiles": 0,
@@ -220,9 +268,25 @@
 		"aiWonderCostModifier": 1,
 		"aiBuildingMaintenanceModifier": 0.1,
 		"aiUnitMaintenanceModifier": 0.1,
-		"aiFreeTechs": ["Secrets of the Past", "Construction", "Redomestication", "Iron Working"],
-		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Civilian Convoy", "Worker", "Scout", "Scout", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiFreeTechs": [
+			"Secrets of the Past",
+			"Construction",
+			"Redomestication",
+			"Iron Working"
+		],
+		"aiMajorCivBonusStartingUnits": [
+			"Civilian Convoy",
+			"Civilian Convoy",
+			"Worker",
+			"Scout",
+			"Scout",
+			"Scout"
+		],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 0.5,
 		"aisExchangeTechs": true,
 		"turnBarbariansCanEnterPlayerTiles": 0,
@@ -247,7 +311,11 @@
 		"aiUnitMaintenanceModifier": 0.25,
 		"aiFreeTechs": [],
 		"aiMajorCivBonusStartingUnits": ["Civilian Convoy", "Scout"],
-		"aiCityStateBonusStartingUnits": ["Civilian Convoy", "Scout", "Spearman"],
+		"aiCityStateBonusStartingUnits": [
+			"Civilian Convoy",
+			"Scout",
+			"Spearman"
+		],
 		"aiUnhappinessModifier": 0.75,
 		"aisExchangeTechs": true,
 		"turnBarbariansCanEnterPlayerTiles": 0,

--- a/jsons/Eras.json
+++ b/jsons/Eras.json
@@ -1,232 +1,284 @@
 [
-    {
-        "name": "Decivilized era",
-        "researchAgreementCost": 150,
-        "startingSettlerCount": 0, // These values should not include the values given in Difficulties.json
-        "startingWorkerCount": 0,
-        "startingMilitaryUnitCount": 0,
-        "startingMilitaryUnit": "Scout",
-        "settlerPopulation": 1,
-        "startPercent": 100,
-        "friendBonus": {
-            "Cultured": ["Provides [+3 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn"],
-            "Mercantile": ["Provides [+2] Happiness"],
-            "Religious": ["Provides [+3 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[20] turns"]
-        },
-        "allyBonus": {
-            "Cultured": ["Provides [+6 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn", "Provides [+1 Food] [in all cities] per turn"],
-            "Mercantile": ["Provides [+2] Happiness", "Provides a unique luxury"],
-            "Religious": ["Provides [+6 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[17] turns"]
-        },
-        "iconRGB": [255, 87, 35]
-    },
-    {
-        "name": "Rediscovering era",
-        "researchAgreementCost": 150,
-        "startingSettlerCount": 0,
-        "startingWorkerCount": 0,
-        "startingMilitaryUnitCount": 0,
-        "startingMilitaryUnit": "Scout",
-        "startingGold": 0,
-        "startingCulture": 0,
-        "settlerPopulation": 1,
-        "startPercent": 110,
-        "friendBonus": {
-            "Cultured": ["Provides [+3 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn"],
-            "Mercantile": ["Provides [+2] Happiness"],
-            "Religious": ["Provides [+3 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[20] turns"]
-        },
-        "allyBonus": {
-            "Cultured": ["Provides [+6 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn", "Provides [+1 Food] [in all cities] per turn"],
-            "Mercantile": ["Provides [+2] Happiness", "Provides a unique luxury"],
-            "Religious": ["Provides [+6 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[17] turns"]
-        },
-        "iconRGB": [233, 31, 99]
-    },
-    {
-        "name": "Neofeudal era",
-        "researchAgreementCost": 250,
-        "startingSettlerCount": 0,
-        "startingWorkerCount": 0,
-        "startingMilitaryUnitCount": 0,
-        "startingMilitaryUnit": "Scout",
-        "startingGold": 0,
-        "startingCulture": 0,
-        "settlerPopulation": 1,
-        "startPercent": 120,
-        "friendBonus": {
-            "Cultured": ["Provides [+6 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn"],
-            "Mercantile": ["Provides [+3] Happiness"],
-            "Religious": ["Provides [+6 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[20] turns"]
-        },
-        "allyBonus": {
-            "Cultured": ["Provides [+12 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn", "Provides [+1 Food] [in all cities] per turn"],
-            "Mercantile": ["Provides [+3] Happiness", "Provides a unique luxury"],
-            "Religious": ["Provides [+12 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[17] turns"]
-        },
-        "iconRGB": [157, 39, 176]
-    },
-    {
-        "name": "Rebuilding era",
-        "researchAgreementCost": 250,
-        "startingSettlerCount": 0,
-        "startingWorkerCount": 0,
-        "startingMilitaryUnitCount": 0,
-        "startingMilitaryUnit": "Scout",
-        "startingGold": 0,
-        "startingCulture": 0,
-        "settlerPopulation": 1,
-        "startPercent": 130,
-        "friendBonus": {
-            "Cultured": ["Provides [+6 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn"],
-            "Mercantile": ["Provides [+3] Happiness"],
-            "Religious": ["Provides [+6 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[20] turns"]
-        },
-        "allyBonus": {
-            "Cultured": ["Provides [+12 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn", "Provides [+1 Food] [in all cities] per turn"],
-            "Mercantile": ["Provides [+3] Happiness", "Provides a unique luxury"],
-            "Religious": ["Provides [+12 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[17] turns"]
-        },
-        "iconRGB": [104, 58, 183]
-    },
-    {
-        "name": "Industrial era",
-        "researchAgreementCost": 300,
-        "startingSettlerCount": 0,
-        "startingWorkerCount": 0,
-        "startingMilitaryUnitCount": 0,
-        "startingMilitaryUnit": "Scout",
-        "startingGold": 0,
-        "startingCulture": 0,
-        "settlerPopulation": 1,
-        "startPercent": 140,
-        "friendBonus": {
-            "Cultured": ["Provides [+13 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn"],
-            "Mercantile": ["Provides [+3] Happiness"],
-            "Religious": ["Provides [+13 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[20] turns"]
-        },
-        "allyBonus": {
-            "Cultured": ["Provides [+26 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn", "Provides [+1 Food] [in all cities] per turn"],
-            "Mercantile": ["Provides [+3] Happiness", "Provides a unique luxury"],
-            "Religious": ["Provides [+26 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[17] turns"]
-        },
-        "iconRGB": [63, 81, 182],
-        "uniques": ["May not generate great prophet equivalents naturally",
-            "May buy [Great Sage] units for [200] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([100])",
-            "Starting in this era disables religion"
-        ]
-    },
-    {
-        "name": "Postmodern era",
-        "researchAgreementCost": 350,
-        "startingSettlerCount": 0,
-        "startingWorkerCount": 0,
-        "startingMilitaryUnitCount": 0,
-        "startingMilitaryUnit": "Scout",
-        "startingGold": 0,
-        "startingCulture": 0,
-        "settlerPopulation": 1,
-        "startPercent": 150,
-        "friendBonus": {
-            "Cultured": ["Provides [+13 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn"],
-            "Mercantile": ["Provides [+3] Happiness"],
-            "Religious": ["Provides [+13 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[20] turns"]
-        },
-        "allyBonus": {
-            "Cultured": ["Provides [+26 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn", "Provides [+1 Food] [in all cities] per turn"],
-            "Mercantile": ["Provides [+3] Happiness", "Provides a unique luxury"],
-            "Religious": ["Provides [+26 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[17] turns"]
-        },
-        "iconRGB": [33, 150, 243],
-        "uniques": ["May not generate great prophet equivalents naturally",
-            "May buy [Great Sage] units for [200] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([100])",
-            "Starting in this era disables religion"
-        ]
-    },
-    {
-        "name": "Information era",
-        "researchAgreementCost": 400,
-        "startingSettlerCount": 0,
-        "startingWorkerCount": 0,
-        "startingMilitaryUnitCount": 0,
-        "startingMilitaryUnit": "Scout",
-        "startingGold": 0,
-        "startingCulture": 0,
-        "settlerPopulation": 1,
-        "startPercent": 160,
-        "friendBonus": {
-            "Cultured": ["Provides [+13 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn"],
-            "Mercantile": ["Provides [+3] Happiness"],
-            "Religious": ["Provides [+13 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[20] turns"]
-        },
-        "allyBonus": {
-            "Cultured": ["Provides [+26 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn", "Provides [+1 Food] [in all cities] per turn"],
-            "Mercantile": ["Provides [+3] Happiness", "Provides a unique luxury"],
-            "Religious": ["Provides [+26 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[17] turns"]
-        },
-        "iconRGB": [0, 150, 136],
-        "uniques": ["May not generate great prophet equivalents naturally",
-            "May buy [Great Sage] units for [200] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([100])",
-            "Starting in this era disables religion"
-        ]
-    },
-    {
-        "name": "New Future era",
-        "researchAgreementCost": 400,
-        "startingSettlerCount": 0,
-        "startingWorkerCount": 0,
-        "startingMilitaryUnitCount": 0,
-        "startingMilitaryUnit": "Scout",
-        "startingGold": 0,
-        "startingCulture": 0,
-        "settlerPopulation": 1,
-        "startPercent": 170,
-        "friendBonus": {
-            "Cultured": ["Provides [+13 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn"],
-            "Mercantile": ["Provides [+3] Happiness"],
-            "Religious": ["Provides [+13 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[20] turns"]
-        },
-        "allyBonus": {
-            "Cultured": ["Provides [+26 Culture] per turn"],
-            "Maritime": ["Provides [+2 Food] [in capital] per turn", "Provides [+1 Food] [in all cities] per turn"],
-            "Mercantile": ["Provides [+3] Happiness", "Provides a unique luxury"],
-            "Religious": ["Provides [+26 Faith] per turn"],
-            "Militaristic": ["Provides military units every ≈[17] turns"]
-        },
-        "iconRGB": [76, 176, 81],
-        "uniques": ["May not generate great prophet equivalents naturally",
-            "May buy [Great Sage] units for [200] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([100])",
-            "Starting in this era disables religion"
-        ]
-    }
+	{
+		"name": "Decivilized era",
+		"researchAgreementCost": 150,
+		"startingSettlerCount": 0, // These values should not include the values given in Difficulties.json
+		"startingWorkerCount": 0,
+		"startingMilitaryUnitCount": 0,
+		"startingMilitaryUnit": "Scout",
+		"settlerPopulation": 1,
+		"startPercent": 100,
+		"friendBonus": {
+			"Cultured": ["Provides [+3 Culture] per turn"],
+			"Maritime": ["Provides [+2 Food] [in capital] per turn"],
+			"Mercantile": ["Provides [+2] Happiness"],
+			"Religious": ["Provides [+3 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[20] turns"]
+		},
+		"allyBonus": {
+			"Cultured": ["Provides [+6 Culture] per turn"],
+			"Maritime": [
+				"Provides [+2 Food] [in capital] per turn",
+				"Provides [+1 Food] [in all cities] per turn"
+			],
+			"Mercantile": [
+				"Provides [+2] Happiness",
+				"Provides a unique luxury"
+			],
+			"Religious": ["Provides [+6 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[17] turns"]
+		},
+		"iconRGB": [255, 87, 35]
+	},
+	{
+		"name": "Rediscovering era",
+		"researchAgreementCost": 150,
+		"startingSettlerCount": 0,
+		"startingWorkerCount": 0,
+		"startingMilitaryUnitCount": 0,
+		"startingMilitaryUnit": "Scout",
+		"startingGold": 0,
+		"startingCulture": 0,
+		"settlerPopulation": 1,
+		"startPercent": 110,
+		"friendBonus": {
+			"Cultured": ["Provides [+3 Culture] per turn"],
+			"Maritime": ["Provides [+2 Food] [in capital] per turn"],
+			"Mercantile": ["Provides [+2] Happiness"],
+			"Religious": ["Provides [+3 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[20] turns"]
+		},
+		"allyBonus": {
+			"Cultured": ["Provides [+6 Culture] per turn"],
+			"Maritime": [
+				"Provides [+2 Food] [in capital] per turn",
+				"Provides [+1 Food] [in all cities] per turn"
+			],
+			"Mercantile": [
+				"Provides [+2] Happiness",
+				"Provides a unique luxury"
+			],
+			"Religious": ["Provides [+6 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[17] turns"]
+		},
+		"iconRGB": [233, 31, 99]
+	},
+	{
+		"name": "Neofeudal era",
+		"researchAgreementCost": 250,
+		"startingSettlerCount": 0,
+		"startingWorkerCount": 0,
+		"startingMilitaryUnitCount": 0,
+		"startingMilitaryUnit": "Scout",
+		"startingGold": 0,
+		"startingCulture": 0,
+		"settlerPopulation": 1,
+		"startPercent": 120,
+		"friendBonus": {
+			"Cultured": ["Provides [+6 Culture] per turn"],
+			"Maritime": ["Provides [+2 Food] [in capital] per turn"],
+			"Mercantile": ["Provides [+3] Happiness"],
+			"Religious": ["Provides [+6 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[20] turns"]
+		},
+		"allyBonus": {
+			"Cultured": ["Provides [+12 Culture] per turn"],
+			"Maritime": [
+				"Provides [+2 Food] [in capital] per turn",
+				"Provides [+1 Food] [in all cities] per turn"
+			],
+			"Mercantile": [
+				"Provides [+3] Happiness",
+				"Provides a unique luxury"
+			],
+			"Religious": ["Provides [+12 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[17] turns"]
+		},
+		"iconRGB": [157, 39, 176]
+	},
+	{
+		"name": "Rebuilding era",
+		"researchAgreementCost": 250,
+		"startingSettlerCount": 0,
+		"startingWorkerCount": 0,
+		"startingMilitaryUnitCount": 0,
+		"startingMilitaryUnit": "Scout",
+		"startingGold": 0,
+		"startingCulture": 0,
+		"settlerPopulation": 1,
+		"startPercent": 130,
+		"friendBonus": {
+			"Cultured": ["Provides [+6 Culture] per turn"],
+			"Maritime": ["Provides [+2 Food] [in capital] per turn"],
+			"Mercantile": ["Provides [+3] Happiness"],
+			"Religious": ["Provides [+6 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[20] turns"]
+		},
+		"allyBonus": {
+			"Cultured": ["Provides [+12 Culture] per turn"],
+			"Maritime": [
+				"Provides [+2 Food] [in capital] per turn",
+				"Provides [+1 Food] [in all cities] per turn"
+			],
+			"Mercantile": [
+				"Provides [+3] Happiness",
+				"Provides a unique luxury"
+			],
+			"Religious": ["Provides [+12 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[17] turns"]
+		},
+		"iconRGB": [104, 58, 183]
+	},
+	{
+		"name": "Industrial era",
+		"researchAgreementCost": 300,
+		"startingSettlerCount": 0,
+		"startingWorkerCount": 0,
+		"startingMilitaryUnitCount": 0,
+		"startingMilitaryUnit": "Scout",
+		"startingGold": 0,
+		"startingCulture": 0,
+		"settlerPopulation": 1,
+		"startPercent": 140,
+		"friendBonus": {
+			"Cultured": ["Provides [+13 Culture] per turn"],
+			"Maritime": ["Provides [+2 Food] [in capital] per turn"],
+			"Mercantile": ["Provides [+3] Happiness"],
+			"Religious": ["Provides [+13 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[20] turns"]
+		},
+		"allyBonus": {
+			"Cultured": ["Provides [+26 Culture] per turn"],
+			"Maritime": [
+				"Provides [+2 Food] [in capital] per turn",
+				"Provides [+1 Food] [in all cities] per turn"
+			],
+			"Mercantile": [
+				"Provides [+3] Happiness",
+				"Provides a unique luxury"
+			],
+			"Religious": ["Provides [+26 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[17] turns"]
+		},
+		"iconRGB": [63, 81, 182],
+		"uniques": [
+			"May not generate great prophet equivalents naturally",
+			"May buy [Great Sage] units for [200] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([100])",
+			"Starting in this era disables religion"
+		]
+	},
+	{
+		"name": "Postmodern era",
+		"researchAgreementCost": 350,
+		"startingSettlerCount": 0,
+		"startingWorkerCount": 0,
+		"startingMilitaryUnitCount": 0,
+		"startingMilitaryUnit": "Scout",
+		"startingGold": 0,
+		"startingCulture": 0,
+		"settlerPopulation": 1,
+		"startPercent": 150,
+		"friendBonus": {
+			"Cultured": ["Provides [+13 Culture] per turn"],
+			"Maritime": ["Provides [+2 Food] [in capital] per turn"],
+			"Mercantile": ["Provides [+3] Happiness"],
+			"Religious": ["Provides [+13 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[20] turns"]
+		},
+		"allyBonus": {
+			"Cultured": ["Provides [+26 Culture] per turn"],
+			"Maritime": [
+				"Provides [+2 Food] [in capital] per turn",
+				"Provides [+1 Food] [in all cities] per turn"
+			],
+			"Mercantile": [
+				"Provides [+3] Happiness",
+				"Provides a unique luxury"
+			],
+			"Religious": ["Provides [+26 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[17] turns"]
+		},
+		"iconRGB": [33, 150, 243],
+		"uniques": [
+			"May not generate great prophet equivalents naturally",
+			"May buy [Great Sage] units for [200] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([100])",
+			"Starting in this era disables religion"
+		]
+	},
+	{
+		"name": "Information era",
+		"researchAgreementCost": 400,
+		"startingSettlerCount": 0,
+		"startingWorkerCount": 0,
+		"startingMilitaryUnitCount": 0,
+		"startingMilitaryUnit": "Scout",
+		"startingGold": 0,
+		"startingCulture": 0,
+		"settlerPopulation": 1,
+		"startPercent": 160,
+		"friendBonus": {
+			"Cultured": ["Provides [+13 Culture] per turn"],
+			"Maritime": ["Provides [+2 Food] [in capital] per turn"],
+			"Mercantile": ["Provides [+3] Happiness"],
+			"Religious": ["Provides [+13 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[20] turns"]
+		},
+		"allyBonus": {
+			"Cultured": ["Provides [+26 Culture] per turn"],
+			"Maritime": [
+				"Provides [+2 Food] [in capital] per turn",
+				"Provides [+1 Food] [in all cities] per turn"
+			],
+			"Mercantile": [
+				"Provides [+3] Happiness",
+				"Provides a unique luxury"
+			],
+			"Religious": ["Provides [+26 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[17] turns"]
+		},
+		"iconRGB": [0, 150, 136],
+		"uniques": [
+			"May not generate great prophet equivalents naturally",
+			"May buy [Great Sage] units for [200] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([100])",
+			"Starting in this era disables religion"
+		]
+	},
+	{
+		"name": "New Future era",
+		"researchAgreementCost": 400,
+		"startingSettlerCount": 0,
+		"startingWorkerCount": 0,
+		"startingMilitaryUnitCount": 0,
+		"startingMilitaryUnit": "Scout",
+		"startingGold": 0,
+		"startingCulture": 0,
+		"settlerPopulation": 1,
+		"startPercent": 170,
+		"friendBonus": {
+			"Cultured": ["Provides [+13 Culture] per turn"],
+			"Maritime": ["Provides [+2 Food] [in capital] per turn"],
+			"Mercantile": ["Provides [+3] Happiness"],
+			"Religious": ["Provides [+13 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[20] turns"]
+		},
+		"allyBonus": {
+			"Cultured": ["Provides [+26 Culture] per turn"],
+			"Maritime": [
+				"Provides [+2 Food] [in capital] per turn",
+				"Provides [+1 Food] [in all cities] per turn"
+			],
+			"Mercantile": [
+				"Provides [+3] Happiness",
+				"Provides a unique luxury"
+			],
+			"Religious": ["Provides [+26 Faith] per turn"],
+			"Militaristic": ["Provides military units every ≈[17] turns"]
+		},
+		"iconRGB": [76, 176, 81],
+		"uniques": [
+			"May not generate great prophet equivalents naturally",
+			"May buy [Great Sage] units for [200] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([100])",
+			"Starting in this era disables religion"
+		]
+	}
 ]

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -2,51 +2,65 @@
 	{
 		"name": "Adaptation",
 		"era": "Decivilized era",
-		"uniques": ["[+3 Culture] [in capital]",
-			"[-25]% Culture cost of natural border growth [in all cities]"],
+		"uniques": [
+			"[+3 Culture] [in capital]",
+			"[-25]% Culture cost of natural border growth [in all cities]"
+		],
 		"policies": [
 			{
 				"name": "Castle Doctrine",
-				"uniques": ["[+25]% City Strength from defensive buildings",
+				"uniques": [
+					"[+25]% City Strength from defensive buildings",
 					"[+50]% Strength for cities <with a garrison> <when attacking>",
-					"[+1 Happiness] [in all cities with a garrison]"],
+					"[+1 Happiness] [in all cities with a garrison]"
+				],
 				"row": 1,
 				"column": 1
 			},
 			{
 				"name": "Centralization",
-				"uniques": ["[+10]% growth [in capital]",
-					"[+2 Food] [in capital]"],
+				"uniques": [
+					"[+10]% growth [in capital]",
+					"[+2 Food] [in capital]"
+				],
 				"row": 1,
 				"column": 3
 			},
 			{
 				"name": "Differential Rationing",
-				"uniques": ["[-50]% Food consumption by specialists [in all cities]"],
+				"uniques": [
+					"[-50]% Food consumption by specialists [in all cities]"
+				],
 				"row": 1,
 				"column": 5
-			},			
+			},
 			{
 				"name": "Planned Economy",
-				"uniques": ["[+25]% growth [in all cities]",
-					"[+33]% [Production] from every [Council]"],
-				"requires": ["Castle Doctrine","Centralization"],
+				"uniques": [
+					"[+25]% growth [in all cities]",
+					"[+33]% [Production] from every [Council]"
+				],
+				"requires": ["Castle Doctrine", "Centralization"],
 				"row": 2,
 				"column": 2
 			},
 			{
 				"name": "Parallel Markets",
-				"uniques": ["[+1 Gold, +1 Happiness] per [2] population [in capital]"],
+				"uniques": [
+					"[+1 Gold, +1 Happiness] per [2] population [in capital]"
+				],
 				"requires": ["Centralization", "Differential Rationing"],
 				"row": 2,
 				"column": 4
-			},			
+			},
 
 			{
 				"name": "Adaptation Complete",
-				"uniques": ["[+10]% growth [in all cities]",
+				"uniques": [
+					"[+10]% growth [in all cities]",
 					"[+2 Food] [in all cities]",
-					"Provides a [Walls] in your first [4] cities for free"]
+					"Provides a [Walls] in your first [4] cities for free"
+				]
 			}
 		]
 	},
@@ -57,92 +71,115 @@
 		"policies": [
 			{
 				"name": "Restorers",
-				"uniques": ["[+50]% Production when constructing [Civilian Convoy] units [in capital]",
+				"uniques": [
+					"[+50]% Production when constructing [Civilian Convoy] units [in capital]",
 					"Free [Civilian Convoy] appears",
-					"[+1] Movement <for [Civilian Convoy] units>"],
+					"[+1] Movement <for [Civilian Convoy] units>"
+				],
 				"row": 1,
 				"column": 1
 			},
 			{
 				"name": "Representation",
-				"uniques": ["Each city founded increases culture cost of policies [33]% less than normal",
-					"[+5 Happiness] from every [Congress]"],
+				"uniques": [
+					"Each city founded increases culture cost of policies [33]% less than normal",
+					"[+5 Happiness] from every [Congress]"
+				],
 				"row": 1,
 				"column": 2
-			},	
+			},
 			{
 				"name": "Courier Service",
-				"uniques": ["[+1 Happiness] [in all cities connected to capital]",
+				"uniques": [
+					"[+1 Happiness] [in all cities connected to capital]",
 					"[-10]% unhappiness from population [in all cities]",
-					"[-50]% City-State Influence degradation"],
+					"[-50]% City-State Influence degradation"
+				],
 				"row": 1,
 				"column": 5
 			},
 			{
 				"name": "Reclaimers",
-				"uniques": ["Double quantity of [Coal] produced",
+				"uniques": [
+					"Double quantity of [Coal] produced",
 					"Double quantity of [Oil] produced",
-					"Double quantity of [Aluminum] produced"],
+					"Double quantity of [Aluminum] produced"
+				],
 				"requires": ["Restorers"],
 				"row": 2,
 				"column": 1
-			},		
+			},
 			{
 				"name": "Citizen Militia",
-				"uniques": ["Units in cities cost no Maintenance",
+				"uniques": [
+					"Units in cities cost no Maintenance",
 					"[+2 Production] [in all cities with a garrison]",
-					"[-33]% maintenance costs <for [Civilian] units>"],
-				"requires": ["Representation","Courier Service"],
+					"[-33]% maintenance costs <for [Civilian] units>"
+				],
+				"requires": ["Representation", "Courier Service"],
 				"row": 2,
 				"column": 3
 			},
 			{
 				"name": "Expansionism Complete",
-				"uniques": ["Free Great Person",
-					"Allied City-States will occasionally gift Great People"]
+				"uniques": [
+					"Free Great Person",
+					"Allied City-States will occasionally gift Great People"
+				]
 			}
 		]
 	},
 	{
 		"name": "Sovereignty",
 		"era": "Decivilized era",
-		"uniques": ["[+33]% Strength <vs [Barbarian] units>",
+		"uniques": [
+			"[+33]% Strength <vs [Barbarian] units>",
 			"Earn [75]% of killed [Barbarian] unit's [Strength] as [Culture]",
-			"Notified of new Barbarian encampments"],
+			"Notified of new Barbarian encampments"
+		],
 		"policies": [
-
 			{
 				"name": "Discipline",
-				"uniques": ["[+15]% Strength <for [Melee] units> <when adjacent to a [Melee] unit>"],
+				"uniques": [
+					"[+15]% Strength <for [Melee] units> <when adjacent to a [Melee] unit>"
+				],
 				"row": 1,
 				"column": 1
-			},	
+			},
 			{
 				"name": "Doctrine",
-				"uniques": ["[+15]% Production when constructing [Land] units [in all cities]",
-					"Earn [25]% of killed [Military] unit's [Strength] as [Culture]"],
+				"uniques": [
+					"[+15]% Production when constructing [Land] units [in all cities]",
+					"Earn [25]% of killed [Military] unit's [Strength] as [Culture]"
+				],
 				"row": 1,
 				"column": 2
 			},
 			{
 				"name": "Autocracy",
-				"uniques": ["[+2 Happiness, +1 Culture] [in all cities with a garrison]",
-					"Double quantity of [Slaves] produced"],
+				"uniques": [
+					"[+2 Happiness, +1 Culture] [in all cities with a garrison]",
+					"Double quantity of [Slaves] produced"
+				],
 				"row": 1,
 				"column": 3
 			},
 			{
 				"name": "Military Tradition",
-				"uniques":["[50]% XP gained from combat <for [Military] units>",
-					"Militaristic City-States grant units [2] times as fast when you are at war with a common nation"],
-				"requires": ["Doctrine","Discipline"],
+				"uniques": [
+					"[50]% XP gained from combat <for [Military] units>",
+					"Militaristic City-States grant units [2] times as fast when you are at war with a common nation"
+				],
+				"requires": ["Doctrine", "Discipline"],
 				"row": 2,
 				"column": 1
-			},		
+			},
 			{
 				"name": "Triumph",
-				"uniques": ["Earn [10]% of killed [Military] unit's [Cost] as [Gold]",
-					"Earn [50]% of killed [Military] unit's [Strength] as [Culture]"],
+				"uniques": [
+					"Earn [10]% of killed [Military] unit's [Cost] as [Gold]",
+					"Earn [50]% of killed [Military] unit's [Strength] as [Culture]"
+				],
 				"requires": ["Doctrine"],
 				"row": 2,
 				"column": 3
@@ -150,27 +187,37 @@
 
 			{
 				"name": "Sovereignty Complete",
-				"uniques": ["[-33]% Gold cost of upgrading <for [Military] units>",
-					"[-25]% maintenance costs <for [All] units>"]
+				"uniques": [
+					"[-33]% Gold cost of upgrading <for [Military] units>",
+					"[-25]% maintenance costs <for [All] units>"
+				]
 			}
 		]
 	},
 	{
 		"name": "Theocracy",
 		"era": "Rediscovering era",
-		"uniques": ["[+100]% Production when constructing [Shrine] buildings [in all cities]", "[+100]% Production when constructing [Monastery] buildings [in all cities]", 
-			"Only available <before adopting [Rationalism]>"],
+		"uniques": [
+			"[+100]% Production when constructing [Shrine] buildings [in all cities]",
+			"[+100]% Production when constructing [Monastery] buildings [in all cities]",
+			"Only available <before adopting [Rationalism]>"
+		],
 		"policies": [
 			{
 				"name": "Organized Religion",
-				"uniques": ["[+1 Faith, -1 Science] from every [Shrine]","[+1 Faith, -1 Science] from every [Monastery]"],
+				"uniques": [
+					"[+1 Faith, -1 Science] from every [Shrine]",
+					"[+1 Faith, -1 Science] from every [Monastery]"
+				],
 				"row": 1,
 				"column": 2
 			},
 			{
 				"name": "Mandate Of Heaven",
-				"uniques": ["[+25]% Strength <for [Wounded] units>",
-					"[+10]% Strength <for [All] units> <during a Golden Age>"],
+				"uniques": [
+					"[+25]% Strength <for [Wounded] units>",
+					"[+10]% Strength <for [All] units> <during a Golden Age>"
+				],
 				"row": 1,
 				"column": 5
 			},
@@ -183,81 +230,101 @@
 			},
 			{
 				"name": "God Emperor",
-				"uniques": ["[+1 Happiness, +1 Culture] from every [Monument]", "Empire enters golden age"],
+				"uniques": [
+					"[+1 Happiness, +1 Culture] from every [Monument]",
+					"Empire enters golden age"
+				],
 				"requires": ["Organized Religion"],
 				"row": 2,
 				"column": 3
 			},
 			{
 				"name": "Holy Scriptures",
-				"uniques": ["[-10]% Culture cost of adopting new Policies",
-					"[+1 Faith, -1 Science] from every [University]"],
+				"uniques": [
+					"[-10]% Culture cost of adopting new Policies",
+					"[+1 Faith, -1 Science] from every [University]"
+				],
 				"requires": ["Mandate Of Heaven", "God Emperor"],
 				"row": 3,
 				"column": 4
 			},
 			{
 				"name": "Theocracy Complete",
-				"uniques": ["[Faith] cost of purchasing items in cities [-20]%", "[+2 Gold, +2 Culture, +1 Faith] from every [Seminary]"]
+				"uniques": [
+					"[Faith] cost of purchasing items in cities [-20]%",
+					"[+2 Gold, +2 Culture, +1 Faith] from every [Seminary]"
+				]
 			}
 		]
 	},
 	{
 		"name": "Monopoly",
-		"uniques": ["[Great Merchant] is earned [20]% faster",
+		"uniques": [
+			"[Great Merchant] is earned [20]% faster",
 			"[+33]% [Gold] from every [Council]",
-			"Only available <before adopting [Collectivism]>"],
+			"Only available <before adopting [Collectivism]>"
+		],
 		"era": "Neofeudal era",
 		"policies": [
-
 			{
 				"name": "Mass Consumption",
-				"uniques": ["[+50]% Happiness from luxury resources gifted by City-States",
+				"uniques": [
+					"[+50]% Happiness from luxury resources gifted by City-States",
 					"[+1] Happiness from each type of luxury resource",
-					"[+3 Gold, -1 Production, -1 Food] from every [Factory]"],
+					"[+3 Gold, -1 Production, -1 Food] from every [Factory]"
+				],
 				"row": 1,
 				"column": 1
-			},		
+			},
 			{
 				"name": "Venture Capital",
-				"uniques": ["[Great Merchant] is earned [20]% faster",
+				"uniques": [
+					"[Great Merchant] is earned [20]% faster",
 					"[Gold] cost of purchasing items in cities [-20]%",
-					"[+100]% Gold from Great Merchant trade missions"],
+					"[+100]% Gold from Great Merchant trade missions"
+				],
 				"row": 1,
 				"column": 3
 			},
 			{
 				"name": "Privatization",
-				"uniques": ["[-50]% maintenance on road & railroads",
+				"uniques": [
+					"[-50]% maintenance on road & railroads",
 					"[Personnel] units gain the [Hazard Pay] promotion",
 					"[+2 Gold] from every [Hospital]",
 					"[+2 Gold, -1 Production] from every [Factory]",
-					"[+2 Gold, -1 Science] from every [Public School]"],
+					"[+2 Gold, -1 Science] from every [Public School]"
+				],
 				"requires": ["Venture Capital"],
 				"row": 2,
 				"column": 2
-			},			
+			},
 			{
 				"name": "Entrepreneurship",
-				"uniques": ["[Great Merchant] is earned [20]% faster",
+				"uniques": [
+					"[Great Merchant] is earned [20]% faster",
 					"[+1 Science] from every [Market]",
-					"[+1 Science] from every [Factory]"], 
+					"[+1 Science] from every [Factory]"
+				],
 				"requires": ["Venture Capital"],
 				"row": 2,
 				"column": 3
-			},	
+			},
 			{
 				"name": "Corporate Personhood",
-				"uniques": ["[-33]% maintenance costs <for [All] units>",
+				"uniques": [
+					"[-33]% maintenance costs <for [All] units>",
 					"[+1 Gold] from every [Strategic Resource]",
-					"[+2 Gold, -1 Food] from every [Factory]"],
-				"requires": ["Venture Capital","Privatization"],
+					"[+2 Gold, -1 Food] from every [Factory]"
+				],
+				"requires": ["Venture Capital", "Privatization"],
 				"row": 3,
 				"column": 3
 			},
 			{
 				"name": "Monopoly Complete",
-				"uniques": ["[-50]% Gold cost of acquiring tiles [in all cities]",
+				"uniques": [
+					"[-50]% Gold cost of acquiring tiles [in all cities]",
 					"[-15]% maintenance cost for buildings [in all cities]",
 					"[+2 Gold, -1 Production, -1 Food] from every [Work Camp]",
 					"May buy [Great Merchant] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
@@ -268,54 +335,67 @@
 	{
 		"name": "Constitution",
 		"era": "Neofeudal era",
-		"uniques": ["[+25]% great person generation [in all cities]",
-			"Only available <before adopting [Supremacy]>"],
+		"uniques": [
+			"[+25]% great person generation [in all cities]",
+			"Only available <before adopting [Supremacy]>"
+		],
 		"policies": [
 			{
 				"name": "Civil Society",
-				"uniques": ["Specialists only produce [50]% of normal unhappiness",
+				"uniques": [
+					"Specialists only produce [50]% of normal unhappiness",
 					"[+1 Happiness] from every [Town Hall]",
-					"[+10]% growth [in all cities]"],
+					"[+10]% growth [in all cities]"
+				],
 				"row": 1,
 				"column": 1
-			},			
+			},
 			{
 				"name": "Protected Speech",
-				"uniques": ["[+1 Culture] per [3] population [in all cities]",
+				"uniques": [
+					"[+1 Culture] per [3] population [in all cities]",
 					"[+1 Culture] from every [Town Hall]",
-					"[+10]% growth [in all cities]"],
+					"[+10]% growth [in all cities]"
+				],
 				"row": 1,
 				"column": 3
 			},
 			{
 				"name": "Public Good",
-				"uniques": ["[+2 Gold] from every [Hospital]",
+				"uniques": [
+					"[+2 Gold] from every [Hospital]",
 					"[-33]% maintenance on road & railroads",
-					"[+20]% growth [in all cities]"],
+					"[+20]% growth [in all cities]"
+				],
 				"requires": ["Civil Society"],
 				"row": 2,
 				"column": 1
 			},
 			{
 				"name": "Legislative Process",
-				"uniques": ["[+25]% [Culture] from every [Congress]",
+				"uniques": [
+					"[+25]% [Culture] from every [Congress]",
 					"[+1 Happiness] per [5] population [in all cities]",
-					"[Great Administrator] is earned [25]% faster"],
-				"requires": ["Civil Society","Protected Speech"],
+					"[Great Administrator] is earned [25]% faster"
+				],
+				"requires": ["Civil Society", "Protected Speech"],
 				"row": 2,
 				"column": 2
-			},			
+			},
 			{
 				"name": "Voting Rights",
-				"uniques": ["[50]% of excess happiness converted to [Culture]",
-					"[-1 Happiness] from every [Work Camp]"],
+				"uniques": [
+					"[50]% of excess happiness converted to [Culture]",
+					"[-1 Happiness] from every [Work Camp]"
+				],
 				"requires": ["Protected Speech"],
 				"row": 2,
 				"column": 3
 			},
 			{
 				"name": "Constitution Complete",
-				"uniques": ["[+100]% Yield from every [Great Improvement]",
+				"uniques": [
+					"[+100]% Yield from every [Great Improvement]",
 					"Free Social Policy",
 					"May buy [Great Administrator] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
 				]
@@ -325,58 +405,68 @@
 	{
 		"name": "Supremacy",
 		"era": "Neofeudal era",
-		"uniques": ["[8] units cost no maintenance",
+		"uniques": [
+			"[8] units cost no maintenance",
 			"[+33]% Production when constructing [Barracks] buildings [in all cities]",
 			"[+33]% Production when constructing [Military Academy] wonders [in all cities]",
 			"Upon capturing a city, receive [10] times its [Culture] production as [Culture] immediately",
-			"Only available <before adopting [Constitution]>"],
+			"Only available <before adopting [Constitution]>"
+		],
 		"policies": [
-
 			{
 				"name": "Militarism",
 				"uniques": ["[Gold] cost of purchasing [All] units [-33]%"],
 				"row": 1,
 				"column": 1
-			},		
+			},
 			{
 				"name": "Scorched Earth",
-				"uniques": ["[+15]% Strength <vs cities>",
+				"uniques": [
+					"[+15]% Strength <vs cities>",
 					"Cities are razed [2] times as fast",
 					"No movement cost to pillage <for [Melee] units>",
-					"[+2] Movement <for [Great General] units>"],
+					"[+2] Movement <for [Great General] units>"
+				],
 				"row": 1,
 				"column": 5
-			},			
+			},
 			{
 				"name": "Police State",
-				"uniques": ["[+1 Happiness] from every [Town Hall]",
+				"uniques": [
+					"[+1 Happiness] from every [Town Hall]",
 					"[+3 Happiness] from every [Listening Post]",
-					"[+5 Happiness, -2 Food] from every [Prison Camp]"],
-				"requires": ["Scorched Earth","Militarism"],
+					"[+5 Happiness, -2 Food] from every [Prison Camp]"
+				],
+				"requires": ["Scorched Earth", "Militarism"],
 				"row": 2,
 				"column": 3
-			},		
+			},
 			{
 				"name": "Total War",
-				"uniques": ["[+15]% Production when constructing [Military] units [in all cities]",
-					"New [Military] units start with [15] Experience [in all cities]"],
+				"uniques": [
+					"[+15]% Production when constructing [Military] units [in all cities]",
+					"New [Military] units start with [15] Experience [in all cities]"
+				],
 				"requires": ["Scorched Earth"],
 				"row": 2,
 				"column": 5
 			},
-		
+
 			{
 				"name": "Spoils of War",
-				"uniques": ["Quantity of strategic resources produced by the empire +[100]%",
+				"uniques": [
+					"Quantity of strategic resources produced by the empire +[100]%",
 					"[-2 Food] from every [Listening Post]",
-					"[-4 Food, +3 Production] from every [Prison Camp]"],
+					"[-4 Food, +3 Production] from every [Prison Camp]"
+				],
 				"requires": ["Police State"],
 				"row": 3,
 				"column": 3
-			},		
+			},
 			{
 				"name": "Supremacy Complete",
-				"uniques": ["[+25]% Strength <when attacking> <for [Military] units> <for [50] turns>",
+				"uniques": [
+					"[+25]% Strength <when attacking> <for [Military] units> <for [50] turns>",
 					"May buy [Great General] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
 				]
 			}
@@ -384,108 +474,137 @@
 	},
 	{
 		"name": "Collectivism",
-   		"era": "Neofeudal era",
-		"uniques": ["[Great Engineer] is earned [25]% faster",
-			"Only available <before adopting [Monopoly]>"],
-    	"policies": [
+		"era": "Neofeudal era",
+		"uniques": [
+			"[Great Engineer] is earned [25]% faster",
+			"Only available <before adopting [Monopoly]>"
+		],
+		"policies": [
 			{
 				"name": "Re-Education",
-				"uniques": ["[-1 Culture] [in all cities]",
+				"uniques": [
+					"[-1 Culture] [in all cities]",
 					"[+1 Happiness, +1 Science] from every [Library]",
 					"[+1 Happiness, +1 Science] from every [Listening Post]",
-					"[+1 Happiness, +1 Science] from every [Prison Camp]"],
+					"[+1 Happiness, +1 Science] from every [Prison Camp]"
+				],
 				"row": 1,
 				"column": 1
 			},
 			{
 				"name": "Nationalization",
-				"uniques": ["[+25]% [Science] from every [Factory]", "[+100]% Production when constructing [Factory] buildings [in all cities]"],
+				"uniques": [
+					"[+25]% [Science] from every [Factory]",
+					"[+100]% Production when constructing [Factory] buildings [in all cities]"
+				],
 				"row": 1,
 				"column": 3
 			},
 			{
 				"name": "Political Officers",
-				"uniques": ["[+15]% Strength <for [All] units> <when fighting in [Friendly Land] tiles>",
-					"[+33]% Strength for cities <when defending>"],
+				"uniques": [
+					"[+15]% Strength <for [All] units> <when fighting in [Friendly Land] tiles>",
+					"[+33]% Strength for cities <when defending>"
+				],
 				"row": 1,
 				"column": 5
 			},
 			{
 				"name": "Shared Vision",
 				"requires": ["Nationalization"],
-				"uniques": ["[-15]% maintenance cost for buildings [in all cities]",
-					"[+1 Production] from every specialist [in all cities]"],
+				"uniques": [
+					"[-15]% maintenance cost for buildings [in all cities]",
+					"[+1 Production] from every specialist [in all cities]"
+				],
 				"row": 2,
 				"column": 3
 			},
 			{
 				"name": "Workers' Union",
 				"requires": ["Shared Vision"],
-				"uniques": ["[+2 Production] [in all cities]", "[+1 Production] from every [Mine]", "[+1 Production] from every [Manufactory]"],
+				"uniques": [
+					"[+2 Production] [in all cities]",
+					"[+1 Production] from every [Mine]",
+					"[+1 Production] from every [Manufactory]"
+				],
 				"row": 3,
 				"column": 3
 			},
 			{
 				"name": "Collectivism Complete",
-				"uniques": ["[+2 Food, +2 Production, +1 Gold] [in all cities]",
+				"uniques": [
+					"[+2 Food, +2 Production, +1 Gold] [in all cities]",
 					"May buy [Great Engineer] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
 				]
-       		}
-    	]
+			}
+		]
 	},
 	{
 		"name": "Rationalism",
 		"era": "Industrial era",
-		"uniques": ["[Great Scientist] is earned [20]% faster",
+		"uniques": [
+			"[Great Scientist] is earned [20]% faster",
 			"Science gained from research agreements [+50]%",
-			"Only available <before adopting [Theocracy]>"],
+			"Only available <before adopting [Theocracy]>"
+		],
 		"policies": [
 			{
 				"name": "Educated Elite",
-				"uniques": ["[+1 Science] from every specialist [in all cities]",
-					"Allied City-States provide [Science] equal to [25]% of what they produce for themselves"],
+				"uniques": [
+					"[+1 Science] from every specialist [in all cities]",
+					"Allied City-States provide [Science] equal to [25]% of what they produce for themselves"
+				],
 				"row": 1,
 				"column": 1
 			},
 
 			{
 				"name": "Skepticism",
-				"uniques": ["[+1 Happiness, -1 Faith] from every [University]",
+				"uniques": [
+					"[+1 Happiness, -1 Faith] from every [University]",
 					"[+1 Happiness, -1 Faith] from every [Data Center]",
-					"[+1 Happiness, -1 Faith] from every [Public School]"],
+					"[+1 Happiness, -1 Faith] from every [Public School]"
+				],
 				"row": 1,
 				"column": 2
-			},			
+			},
 			{
 				"name": "Equipment Upgrades",
-				"uniques": ["[-33]% Gold cost of upgrading <for [Military] units>",
-					"[+1 Science] from every [Barracks]"],
+				"uniques": [
+					"[-33]% Gold cost of upgrading <for [Military] units>",
+					"[+1 Science] from every [Barracks]"
+				],
 				"row": 1,
 				"column": 3
 			},
 			{
 				"name": "Sample Analysis",
-				"uniques": ["[+1 Science] from every [Moisture trap]",
-					"[+17]% [Science] from every [University]"],
+				"uniques": [
+					"[+1 Science] from every [Moisture trap]",
+					"[+17]% [Science] from every [University]"
+				],
 				"requires": ["Educated Elite"],
 				"row": 2,
 				"column": 1
 			},
 			{
 				"name": "Technocracy",
-				"uniques": ["[+25]% [Science] from every [Council]",
-					"[+1 Gold] from all [Science] buildings"],
+				"uniques": [
+					"[+25]% [Science] from every [Council]",
+					"[+1 Gold] from all [Science] buildings"
+				],
 				"requires": ["Skepticism"],
 				"row": 2,
 				"column": 2
 			},
 			{
 				"name": "Rationalism Complete",
-				"uniques": ["[+15]% [Science] <while the empire is happy>",
+				"uniques": [
+					"[+15]% [Science] <while the empire is happy>",
 					"[2] Free Technologies",
-					"May buy [Great Scientist] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"]
+					"May buy [Great Scientist] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
+				]
 			}
 		]
 	}
-	
 ]

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -2,6 +2,13 @@
 	{
 		"name": "Adaptation",
 		"era": "Decivilized era",
+		"priorities": {
+			"Neutral": 0,
+			"Cultural": 30,
+			"Diplomatic": 0,
+			"Domination": 0,
+			"Scientific": 30
+		},
 		"uniques": [
 			"[+3 Culture] [in capital]",
 			"[-25]% Culture cost of natural border growth [in all cities]"
@@ -67,6 +74,13 @@
 	{
 		"name": "Expansionism",
 		"era": "Decivilized era",
+		"priorities": {
+			"Neutral": 30,
+			"Cultural": 0,
+			"Diplomatic": 30,
+			"Domination": 30,
+			"Scientific": 0
+		},
 		"uniques": ["[+1 Culture] [in all cities]"],
 		"policies": [
 			{
@@ -132,6 +146,13 @@
 	{
 		"name": "Sovereignty",
 		"era": "Decivilized era",
+		"priorities": {
+			"Neutral": 10,
+			"Cultural": 10,
+			"Diplomatic": 10,
+			"Domination": 10,
+			"Scientific": 10
+		},
 		"uniques": [
 			"[+33]% Strength <vs [Barbarian] units>",
 			"Earn [75]% of killed [Barbarian] unit's [Strength] as [Culture]",
@@ -197,6 +218,13 @@
 	{
 		"name": "Theocracy",
 		"era": "Neofeudal era",
+		"priorities": {
+			"Neutral": 20,
+			"Cultural": 20,
+			"Diplomatic": 20,
+			"Domination": 20,
+			"Scientific": 0
+		},
 		"uniques": [
 			"[+100]% Production when constructing [Shrine] buildings [in all cities]",
 			"[+100]% Production when constructing [Monastery] buildings [in all cities]",
@@ -260,6 +288,13 @@
 	{
 		"name": "Rationalism",
 		"era": "Neofeudal era",
+		"priorities": {
+			"Neutral": 20,
+			"Cultural": 0,
+			"Diplomatic": 20,
+			"Domination": 20,
+			"Scientific": 20
+		},
 		"uniques": [
 			"[Great Scientist] is earned [20]% faster",
 			"Science gained from research agreements [+50]%",
@@ -328,6 +363,13 @@
 	{
 		"name": "Constitution",
 		"era": "Neofeudal era",
+		"priorities": {
+			"Neutral": 20,
+			"Cultural": 20,
+			"Diplomatic": 20,
+			"Domination": 0,
+			"Scientific": 20
+		},
 		"uniques": [
 			"[+25]% great person generation [in all cities]",
 			"Only available <before adopting [Supremacy]>"
@@ -398,6 +440,13 @@
 	{
 		"name": "Supremacy",
 		"era": "Neofeudal era",
+		"priorities": {
+			"Neutral": 20,
+			"Cultural": 0,
+			"Diplomatic": 20,
+			"Domination": 20,
+			"Scientific": 0
+		},
 		"uniques": [
 			"[8] units cost no maintenance",
 			"[+33]% Production when constructing [Barracks] buildings [in all cities]",
@@ -467,12 +516,19 @@
 	},
 	{
 		"name": "Monopoly",
+		"era": "Neofeudal era",
+		"priorities": {
+			"Neutral": 20,
+			"Cultural": 20,
+			"Diplomatic": 20,
+			"Domination": 20,
+			"Scientific": 20
+		},
 		"uniques": [
 			"[Great Merchant] is earned [20]% faster",
 			"[+33]% [Gold] from every [Council]",
 			"Only available <before adopting [Collectivism]>"
 		],
-		"era": "Neofeudal era",
 		"policies": [
 			{
 				"name": "Mass Consumption",
@@ -543,6 +599,13 @@
 	{
 		"name": "Collectivism",
 		"era": "Neofeudal era",
+		"priorities": {
+			"Neutral": 20,
+			"Cultural": 20,
+			"Diplomatic": 0,
+			"Domination": 20,
+			"Scientific": 20
+		},
 		"uniques": [
 			"[Great Engineer] is earned [25]% faster",
 			"Only available <before adopting [Monopoly]>"

--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -196,7 +196,7 @@
 	},
 	{
 		"name": "Theocracy",
-		"era": "Rediscovering era",
+		"era": "Neofeudal era",
 		"uniques": [
 			"[+100]% Production when constructing [Shrine] buildings [in all cities]",
 			"[+100]% Production when constructing [Monastery] buildings [in all cities]",
@@ -258,76 +258,69 @@
 		]
 	},
 	{
-		"name": "Monopoly",
-		"uniques": [
-			"[Great Merchant] is earned [20]% faster",
-			"[+33]% [Gold] from every [Council]",
-			"Only available <before adopting [Collectivism]>"
-		],
+		"name": "Rationalism",
 		"era": "Neofeudal era",
+		"uniques": [
+			"[Great Scientist] is earned [20]% faster",
+			"Science gained from research agreements [+50]%",
+			"Only available <before adopting [Theocracy]>"
+		],
 		"policies": [
 			{
-				"name": "Mass Consumption",
+				"name": "Educated Elite",
 				"uniques": [
-					"[+50]% Happiness from luxury resources gifted by City-States",
-					"[+1] Happiness from each type of luxury resource",
-					"[+3 Gold, -1 Production, -1 Food] from every [Factory]"
+					"[+1 Science] from every specialist [in all cities]",
+					"Allied City-States provide [Science] equal to [25]% of what they produce for themselves"
 				],
 				"row": 1,
 				"column": 1
 			},
+
 			{
-				"name": "Venture Capital",
+				"name": "Skepticism",
 				"uniques": [
-					"[Great Merchant] is earned [20]% faster",
-					"[Gold] cost of purchasing items in cities [-20]%",
-					"[+100]% Gold from Great Merchant trade missions"
+					"[+1 Happiness, -1 Faith] from every [University]",
+					"[+1 Happiness, -1 Faith] from every [Data Center]",
+					"[+1 Happiness, -1 Faith] from every [Public School]"
+				],
+				"row": 1,
+				"column": 2
+			},
+			{
+				"name": "Equipment Upgrades",
+				"uniques": [
+					"[-33]% Gold cost of upgrading <for [Military] units>",
+					"[+1 Science] from every [Barracks]"
 				],
 				"row": 1,
 				"column": 3
 			},
 			{
-				"name": "Privatization",
+				"name": "Sample Analysis",
 				"uniques": [
-					"[-50]% maintenance on road & railroads",
-					"[Personnel] units gain the [Hazard Pay] promotion",
-					"[+2 Gold] from every [Hospital]",
-					"[+2 Gold, -1 Production] from every [Factory]",
-					"[+2 Gold, -1 Science] from every [Public School]"
+					"[+1 Science] from every [Moisture trap]",
+					"[+17]% [Science] from every [University]"
 				],
-				"requires": ["Venture Capital"],
+				"requires": ["Educated Elite"],
+				"row": 2,
+				"column": 1
+			},
+			{
+				"name": "Technocracy",
+				"uniques": [
+					"[+25]% [Science] from every [Council]",
+					"[+1 Gold] from all [Science] buildings"
+				],
+				"requires": ["Skepticism"],
 				"row": 2,
 				"column": 2
 			},
 			{
-				"name": "Entrepreneurship",
+				"name": "Rationalism Complete",
 				"uniques": [
-					"[Great Merchant] is earned [20]% faster",
-					"[+1 Science] from every [Market]",
-					"[+1 Science] from every [Factory]"
-				],
-				"requires": ["Venture Capital"],
-				"row": 2,
-				"column": 3
-			},
-			{
-				"name": "Corporate Personhood",
-				"uniques": [
-					"[-33]% maintenance costs <for [All] units>",
-					"[+1 Gold] from every [Strategic Resource]",
-					"[+2 Gold, -1 Food] from every [Factory]"
-				],
-				"requires": ["Venture Capital", "Privatization"],
-				"row": 3,
-				"column": 3
-			},
-			{
-				"name": "Monopoly Complete",
-				"uniques": [
-					"[-50]% Gold cost of acquiring tiles [in all cities]",
-					"[-15]% maintenance cost for buildings [in all cities]",
-					"[+2 Gold, -1 Production, -1 Food] from every [Work Camp]",
-					"May buy [Great Merchant] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
+					"[+15]% [Science] <while the empire is happy>",
+					"[2] Free Technologies",
+					"May buy [Great Scientist] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
 				]
 			}
 		]
@@ -473,6 +466,81 @@
 		]
 	},
 	{
+		"name": "Monopoly",
+		"uniques": [
+			"[Great Merchant] is earned [20]% faster",
+			"[+33]% [Gold] from every [Council]",
+			"Only available <before adopting [Collectivism]>"
+		],
+		"era": "Neofeudal era",
+		"policies": [
+			{
+				"name": "Mass Consumption",
+				"uniques": [
+					"[+50]% Happiness from luxury resources gifted by City-States",
+					"[+1] Happiness from each type of luxury resource",
+					"[+3 Gold, -1 Production, -1 Food] from every [Factory]"
+				],
+				"row": 1,
+				"column": 1
+			},
+			{
+				"name": "Venture Capital",
+				"uniques": [
+					"[Great Merchant] is earned [20]% faster",
+					"[Gold] cost of purchasing items in cities [-20]%",
+					"[+100]% Gold from Great Merchant trade missions"
+				],
+				"row": 1,
+				"column": 3
+			},
+			{
+				"name": "Privatization",
+				"uniques": [
+					"[-50]% maintenance on road & railroads",
+					"[Personnel] units gain the [Hazard Pay] promotion",
+					"[+2 Gold] from every [Hospital]",
+					"[+2 Gold, -1 Production] from every [Factory]",
+					"[+2 Gold, -1 Science] from every [Public School]"
+				],
+				"requires": ["Venture Capital"],
+				"row": 2,
+				"column": 2
+			},
+			{
+				"name": "Entrepreneurship",
+				"uniques": [
+					"[Great Merchant] is earned [20]% faster",
+					"[+1 Science] from every [Market]",
+					"[+1 Science] from every [Factory]"
+				],
+				"requires": ["Venture Capital"],
+				"row": 2,
+				"column": 3
+			},
+			{
+				"name": "Corporate Personhood",
+				"uniques": [
+					"[-33]% maintenance costs <for [All] units>",
+					"[+1 Gold] from every [Strategic Resource]",
+					"[+2 Gold, -1 Food] from every [Factory]"
+				],
+				"requires": ["Venture Capital", "Privatization"],
+				"row": 3,
+				"column": 3
+			},
+			{
+				"name": "Monopoly Complete",
+				"uniques": [
+					"[-50]% Gold cost of acquiring tiles [in all cities]",
+					"[-15]% maintenance cost for buildings [in all cities]",
+					"[+2 Gold, -1 Production, -1 Food] from every [Work Camp]",
+					"May buy [Great Merchant] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
+				]
+			}
+		]
+	},
+	{
 		"name": "Collectivism",
 		"era": "Neofeudal era",
 		"uniques": [
@@ -535,74 +603,6 @@
 				"uniques": [
 					"[+2 Food, +2 Production, +1 Gold] [in all cities]",
 					"May buy [Great Engineer] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
-				]
-			}
-		]
-	},
-	{
-		"name": "Rationalism",
-		"era": "Industrial era",
-		"uniques": [
-			"[Great Scientist] is earned [20]% faster",
-			"Science gained from research agreements [+50]%",
-			"Only available <before adopting [Theocracy]>"
-		],
-		"policies": [
-			{
-				"name": "Educated Elite",
-				"uniques": [
-					"[+1 Science] from every specialist [in all cities]",
-					"Allied City-States provide [Science] equal to [25]% of what they produce for themselves"
-				],
-				"row": 1,
-				"column": 1
-			},
-
-			{
-				"name": "Skepticism",
-				"uniques": [
-					"[+1 Happiness, -1 Faith] from every [University]",
-					"[+1 Happiness, -1 Faith] from every [Data Center]",
-					"[+1 Happiness, -1 Faith] from every [Public School]"
-				],
-				"row": 1,
-				"column": 2
-			},
-			{
-				"name": "Equipment Upgrades",
-				"uniques": [
-					"[-33]% Gold cost of upgrading <for [Military] units>",
-					"[+1 Science] from every [Barracks]"
-				],
-				"row": 1,
-				"column": 3
-			},
-			{
-				"name": "Sample Analysis",
-				"uniques": [
-					"[+1 Science] from every [Moisture trap]",
-					"[+17]% [Science] from every [University]"
-				],
-				"requires": ["Educated Elite"],
-				"row": 2,
-				"column": 1
-			},
-			{
-				"name": "Technocracy",
-				"uniques": [
-					"[+25]% [Science] from every [Council]",
-					"[+1 Gold] from all [Science] buildings"
-				],
-				"requires": ["Skepticism"],
-				"row": 2,
-				"column": 2
-			},
-			{
-				"name": "Rationalism Complete",
-				"uniques": [
-					"[+15]% [Science] <while the empire is happy>",
-					"[2] Free Technologies",
-					"May buy [Great Scientist] units for [1000] [Faith] [in all cities in which the majority religion is a major religion] at an increasing price ([500]) <starting from the [Industrial era]>"
 				]
 			}
 		]

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -8,62 +8,6 @@
 	// Base units and player uniques
 	////////////////////
 
-	// Missile
-	{
-		"name": "Divine Spear",
-		"unitType": "Missile",
-		"movement": 1,
-		"strength": 300,
-		"rangedStrength": 300,
-		"range": 8,
-		"cost": 1600,
-		"uniques": [
-			"Only available <if [Faust Project] is constructed>",
-			"Nuclear weapon of Strength [2]",
-			"Blast radius [2]",
-			"Unbuildable",
-			"Consumes [1] [Uranium]"
-		],
-		"hurryCostModifier": 20,
-		"attackSound": "nuke"
-	},
-	{
-		"name": "Tactical Nuke",
-		"unitType": "Missile",
-		"movement": 1,
-		"strength": 150,
-		"rangedStrength": 150,
-		"range": 8,
-		"cost": 600,
-		"requiredTech": "Gyroscopes",
-		"uniques": [
-			"Nuclear weapon of Strength [1]",
-			"Blast radius [1]",
-			"Only available <if [Manhattan Project] is constructed>",
-			"Consumes [1] [Uranium]"
-		],
-		"hurryCostModifier": 20,
-		"attackSound": "nuke"
-	},
-	{
-		"name": "Nuclear Missile",
-		"unitType": "Missile",
-		"movement": 1,
-		"strength": 300,
-		"rangedStrength": 300,
-		"range": 16,
-		"cost": 1000,
-		"requiredTech": "Rocketry",
-		"uniques": [
-			"Nuclear weapon of Strength [2]",
-			"Blast radius [2]",
-			"Only available <if [Manhattan Project] is constructed>",
-			"Consumes [1] [Uranium]"
-		],
-		"hurryCostModifier": 20,
-		"attackSound": "nuke"
-	},
-
 	// Civilian
 
 	//// Civilian Convoy
@@ -118,195 +62,60 @@
 		"hurryCostModifier": 20
 	},
 
-	//// Religious
+	// Missile
 	{
-		"name": "Philosopher",
-		"unitType": "Civilian",
+		"name": "Divine Spear",
+		"unitType": "Missile",
+		"movement": 1,
+		"strength": 300,
+		"rangedStrength": 300,
+		"range": 8,
+		"cost": 1600,
 		"uniques": [
-			"Can [Spread Religion] [2] times",
-			"May enter foreign tiles without open borders, but loses [100] religious strength each turn it ends there",
-			"Can be purchased with [Faith] [in all cities in which the majority religion is a major religion]",
-			"[-1] Sight",
+			"Only available <if [Faust Project] is constructed>",
+			"Nuclear weapon of Strength [2]",
+			"Blast radius [2]",
 			"Unbuildable",
-			"Religious Unit",
-			"Hidden when religion is disabled"
+			"Consumes [1] [Uranium]"
 		],
-		"movement": 4,
-		"religiousStrength": 1000
+		"hurryCostModifier": 20,
+		"attackSound": "nuke"
 	},
 	{
-		"name": "Censor",
-		"unitType": "Civilian",
+		"name": "Tactical Nuke",
+		"unitType": "Missile",
+		"movement": 1,
+		"strength": 150,
+		"rangedStrength": 150,
+		"range": 8,
+		"cost": 600,
+		"requiredTech": "Gyroscopes",
 		"uniques": [
-			"Prevents spreading of religion to the city it is next to",
-			"Can [Remove Foreign religions from your own cities] [2] times",
-			"Can be purchased with [Faith] [in all cities in which the majority religion is an enhanced religion]",
-			"[+1] Sight",
-			"Hidden when religion is disabled",
-			"Unbuildable",
-			"Religious Unit"
+			"Nuclear weapon of Strength [1]",
+			"Blast radius [1]",
+			"Only available <if [Manhattan Project] is constructed>",
+			"Consumes [1] [Uranium]"
 		],
-		"movement": 3
-	},
-
-	//// Great People
-	{
-		"name": "Great Administrator",
-		"unitType": "Civilian",
-		"uniques": [
-			"Can start an [8]-turn golden age",
-			"Can construct [Settlement]",
-			"Great Person - [Culture]",
-			"Unbuildable",
-			"Uncapturable"
-		],
-		"movement": 2
+		"hurryCostModifier": 20,
+		"attackSound": "nuke"
 	},
 	{
-		"name": "Great Prophet",
-		"uniqueTo": "Cult of Ignis",
-		"replaces": "Great Administrator",
-		"unitType": "Civilian",
+		"name": "Nuclear Missile",
+		"unitType": "Missile",
+		"movement": 1,
+		"strength": 300,
+		"rangedStrength": 300,
+		"range": 16,
+		"cost": 1000,
+		"requiredTech": "Rocketry",
 		"uniques": [
-			"Can start an [8]-turn golden age",
-			"Can construct [Oracle]",
-			"Great Person - [Culture]",
-			"Uncapturable",
-			"Unbuildable"
+			"Nuclear weapon of Strength [2]",
+			"Blast radius [2]",
+			"Only available <if [Manhattan Project] is constructed>",
+			"Consumes [1] [Uranium]"
 		],
-		"movement": 2
-	},
-	{
-		"name": "Great Sage",
-		"unitType": "Civilian",
-		"uniques": [
-			"Can construct [Seminary] if it hasn't used other actions yet",
-			"Can [Spread Religion] [4] times",
-			"Removes other religions when spreading religion",
-			"May found a religion",
-			"May enhance a religion",
-			"May enter foreign tiles without open borders",
-			"[-1] Sight",
-			"Great Person - [Faith]",
-			"Unbuildable",
-			"Uncapturable",
-			"Religious Unit",
-			"Hidden when religion is disabled",
-			"Takes your religion over the one in their birth city"
-		],
-		"movement": 2,
-		"religiousStrength": 1000
-	},
-	{
-		"name": "Great Scientist",
-		"unitType": "Civilian",
-		"uniques": [
-			"Can hurry technology research",
-			"Can construct [Academy]",
-			"Great Person - [Science]",
-			"Unbuildable",
-			"Uncapturable"
-		],
-		"movement": 2
-	},
-	{
-		"name": "Great Merchant",
-		"unitType": "Civilian",
-		"uniques": [
-			"Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence",
-			"Can construct [Settlement]",
-			"Great Person - [Gold]",
-			"Unbuildable",
-			"Uncapturable"
-		],
-		"movement": 2
-	},
-	{
-		"name": "Smuggler",
-		"uniqueTo": "Deadrock Clan",
-		"replaces": "Great Merchant",
-		"unitType": "Civilian",
-		"uniques": [
-			"Invisible to non-adjacent units",
-			"Can undertake a trade mission with City-State, giving a large sum of gold and [40] Influence",
-			"Can construct [Narcotics farm]",
-			"Great Person - [Gold]",
-			"Unbuildable",
-			"Uncapturable"
-		],
-		"movement": 2
-	},
-	{
-		"name": "Slave Trader",
-		"uniqueTo": "Crimson Legion",
-		"replaces": "Great Merchant",
-		"unitType": "Civilian",
-		"uniques": [
-			"Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence",
-			"Can construct [Prison farm]",
-			"Great Person - [Gold]",
-			"Unbuildable",
-			"Uncapturable"
-		],
-		"movement": 2
-	},
-	{
-		"name": "Great Engineer",
-		"unitType": "Civilian",
-		"uniques": [
-			"Can speed up construction of a building",
-			"Can construct [Manufactory]",
-			"Great Person - [Production]",
-			"Unbuildable",
-			"Uncapturable"
-		],
-		"movement": 2
-	},
-	{
-		"name": "Great General",
-		"unitType": "Civilian",
-		"uniques": [
-			"Can start an [8]-turn golden age",
-			"Bonus for units in 2 tile radius 15%",
-			"Can construct [Citadel]",
-			"Great Person - [War]",
-			"Unbuildable",
-			"Uncapturable"
-		],
-		"movement": 2
-	},
-	{
-		"name": "Gangboss",
-		"uniqueTo": "Deadrock Clan",
-		"replaces": "Great General",
-		"unitType": "Civilian",
-		"uniques": [
-			"Can build [Land] improvements on tiles",
-			"Can start an [8]-turn golden age",
-			"Bonus for units in 2 tile radius 15%",
-			"Can construct [Prison farm]",
-			"Great Person - [War]",
-			"Unbuildable",
-			"Uncapturable"
-		],
-		"movement": 2
-	},
-	{
-		"name": "Bugler",
-		"uniqueTo": "Cult of Ignis",
-		"replaces": "Great General",
-		"unitType": "Civilian",
-		"uniques": [
-			"Can start an [8]-turn golden age",
-			"Bonus for units in 2 tile radius 15%",
-			"All adjacent units heal [+15] HP when healing",
-			"[+15] HP when healing",
-			"Can construct [Outpost]",
-			"Great Person - [War]",
-			"Uncapturable",
-			"Unbuildable"
-		],
-		"movement": 5
+		"hurryCostModifier": 20,
+		"attackSound": "nuke"
 	},
 
 	// Low Tech
@@ -642,27 +451,6 @@
 		"promotions": ["Urban Warfare I"]
 	},
 
-	//// Unique
-	{
-		"name": "Legion",
-		"unitType": "Scrapper",
-		"uniqueTo": "Crimson Legion",
-		"replaces": "Militia",
-		"movement": 2,
-		"strength": 24,
-		"cost": 50,
-		"requiredTech": "Iron Working",
-		"obsoleteTech": "Combined Arms",
-		"upgradesTo": "Soldier",
-		"uniques": [
-			"Low Tech",
-			"[+50]% Strength <vs cities>",
-			"[+50]% Strength <vs [Low Tech] units>",
-			"Only available <if [Forge] is constructed>"
-		],
-		"attackSound": "metalhit"
-	},
-
 	// Personnel
 
 	//// Melee (Scrapper)
@@ -932,6 +720,25 @@
 		],
 		"promotions": ["Gas Mask"],
 		"attackSound": "machinegun"
+	},
+	{
+		"name": "Legion",
+		"unitType": "Scrapper",
+		"uniqueTo": "Crimson Legion",
+		"replaces": "Militia",
+		"movement": 2,
+		"strength": 24,
+		"cost": 50,
+		"requiredTech": "Iron Working",
+		"obsoleteTech": "Combined Arms",
+		"upgradesTo": "Soldier",
+		"uniques": [
+			"Low Tech",
+			"[+50]% Strength <vs cities>",
+			"[+50]% Strength <vs [Low Tech] units>",
+			"Only available <if [Forge] is constructed>"
+		],
+		"attackSound": "metalhit"
 	},
 	/*
 	{
@@ -2026,6 +1833,199 @@
 			"Consumes [1] [Uranium]"
 		],
 		"attackSound": "torpedo"
+	},
+
+	// Faith-purchasable civilian
+
+	//// Religious
+	{
+		"name": "Philosopher",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can [Spread Religion] [2] times",
+			"May enter foreign tiles without open borders, but loses [100] religious strength each turn it ends there",
+			"Can be purchased with [Faith] [in all cities in which the majority religion is a major religion]",
+			"[-1] Sight",
+			"Unbuildable",
+			"Religious Unit",
+			"Hidden when religion is disabled"
+		],
+		"movement": 4,
+		"religiousStrength": 1000
+	},
+	{
+		"name": "Censor",
+		"unitType": "Civilian",
+		"uniques": [
+			"Prevents spreading of religion to the city it is next to",
+			"Can [Remove Foreign religions from your own cities] [2] times",
+			"Can be purchased with [Faith] [in all cities in which the majority religion is an enhanced religion]",
+			"[+1] Sight",
+			"Hidden when religion is disabled",
+			"Unbuildable",
+			"Religious Unit"
+		],
+		"movement": 3
+	},
+
+	//// Great People
+	{
+		"name": "Great Administrator",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can start an [8]-turn golden age",
+			"Can construct [Settlement]",
+			"Great Person - [Culture]",
+			"Unbuildable",
+			"Uncapturable"
+		],
+		"movement": 2
+	},
+	{
+		"name": "Great Prophet",
+		"uniqueTo": "Cult of Ignis",
+		"replaces": "Great Administrator",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can start an [8]-turn golden age",
+			"Can construct [Oracle]",
+			"Great Person - [Culture]",
+			"Uncapturable",
+			"Unbuildable"
+		],
+		"movement": 2
+	},
+	{
+		"name": "Great Sage",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can construct [Seminary] if it hasn't used other actions yet",
+			"Can [Spread Religion] [4] times",
+			"Removes other religions when spreading religion",
+			"May found a religion",
+			"May enhance a religion",
+			"May enter foreign tiles without open borders",
+			"[-1] Sight",
+			"Great Person - [Faith]",
+			"Unbuildable",
+			"Uncapturable",
+			"Religious Unit",
+			"Hidden when religion is disabled",
+			"Takes your religion over the one in their birth city"
+		],
+		"movement": 2,
+		"religiousStrength": 1000
+	},
+	{
+		"name": "Great Scientist",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can hurry technology research",
+			"Can construct [Academy]",
+			"Great Person - [Science]",
+			"Unbuildable",
+			"Uncapturable"
+		],
+		"movement": 2
+	},
+	{
+		"name": "Great Merchant",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence",
+			"Can construct [Settlement]",
+			"Great Person - [Gold]",
+			"Unbuildable",
+			"Uncapturable"
+		],
+		"movement": 2
+	},
+	{
+		"name": "Smuggler",
+		"uniqueTo": "Deadrock Clan",
+		"replaces": "Great Merchant",
+		"unitType": "Civilian",
+		"uniques": [
+			"Invisible to non-adjacent units",
+			"Can undertake a trade mission with City-State, giving a large sum of gold and [40] Influence",
+			"Can construct [Narcotics farm]",
+			"Great Person - [Gold]",
+			"Unbuildable",
+			"Uncapturable"
+		],
+		"movement": 2
+	},
+	{
+		"name": "Slave Trader",
+		"uniqueTo": "Crimson Legion",
+		"replaces": "Great Merchant",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can undertake a trade mission with City-State, giving a large sum of gold and [30] Influence",
+			"Can construct [Prison farm]",
+			"Great Person - [Gold]",
+			"Unbuildable",
+			"Uncapturable"
+		],
+		"movement": 2
+	},
+	{
+		"name": "Great Engineer",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can speed up construction of a building",
+			"Can construct [Manufactory]",
+			"Great Person - [Production]",
+			"Unbuildable",
+			"Uncapturable"
+		],
+		"movement": 2
+	},
+	{
+		"name": "Great General",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can start an [8]-turn golden age",
+			"Bonus for units in 2 tile radius 15%",
+			"Can construct [Citadel]",
+			"Great Person - [War]",
+			"Unbuildable",
+			"Uncapturable"
+		],
+		"movement": 2
+	},
+	{
+		"name": "Gangboss",
+		"uniqueTo": "Deadrock Clan",
+		"replaces": "Great General",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can build [Land] improvements on tiles",
+			"Can start an [8]-turn golden age",
+			"Bonus for units in 2 tile radius 15%",
+			"Can construct [Prison farm]",
+			"Great Person - [War]",
+			"Unbuildable",
+			"Uncapturable"
+		],
+		"movement": 2
+	},
+	{
+		"name": "Bugler",
+		"uniqueTo": "Cult of Ignis",
+		"replaces": "Great General",
+		"unitType": "Civilian",
+		"uniques": [
+			"Can start an [8]-turn golden age",
+			"Bonus for units in 2 tile radius 15%",
+			"All adjacent units heal [+15] HP when healing",
+			"[+15] HP when healing",
+			"Can construct [Outpost]",
+			"Great Person - [War]",
+			"Uncapturable",
+			"Unbuildable"
+		],
+		"movement": 5
 	},
 
 	////////////////////


### PR DESCRIPTION
- **Reordered units**
  - Missile units are now shown below base civilian units.
  - Religious units and Great People are now shown below military units.
- **Reformatted files**
  - Difficulties.json, Eras.json, Policies.json
- **Reordered Rationalism and Monopoly, Unified the unlocking era of Theocracy and Rationalism into the Neofeudal era**
  - Policy branches are now ordered like the following:
    ```
    Adaptation - Expansion - Sovereignty - Theocracy - Rationalism
    Constitution - Supremacy - Monopoly - Collectivism
    ```
- **Added branch priorities**
  - This would be in effect if https://github.com/yairm210/Unciv/pull/6390 is merged.
  - AI Nations will prioritize finishing a branch before moving on or unless another branch with a higher priority is unlocked.
  ```
  |-----|----|----|----|----|----|
  |     |Neut|Cult|Dipl|Domi|Scie|
  |-----|----|----|----|----|----|
  |Adapt|    | 30 |    |    | 30 |
  |Expan| 30 |    | 30 | 30 |    |
  |Sover| 10 | 10 | 10 | 10 | 10 |
  |-----|----|----|----|----|----|
  |Theoc| 20 | 20 | 20 | 20 |    |
  |Ratio| 20 |    | 20 | 20 | 20 |
  |-----|----|----|----|----|----|
  |Const| 20 | 20 | 20 |    | 20 |
  |Supre| 20 |    | 20 | 20 |    |
  |-----|----|----|----|----|----|
  |Monop| 20 | 20 | 20 | 20 | 20 |
  |Colle| 20 | 20 |    | 20 | 20 |
  |-----|----|----|----|----|----|
  ```