### PR TITLE
Update Units.json

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -244,7 +244,7 @@
 		"cost": 40,
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Militia",
-		"uniques": ["Low Tech"],
+		"uniques": ["Low Tech", "Can construct [Salvage site]"],
 		"promotions": ["Forage"],
 		"attackSound": "nonmetalhit"
 	},


### PR DESCRIPTION
Gave the Scavenger of Children of Rust the ability to construct the Salvage site, which fits both the unit title, the ethos of the nation, and the other national unit uniques.