### PR TITLE
Adding repair tile improvements

### DIFF
--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -373,6 +373,15 @@
 		"uniques": ["Can be built outside your borders"],
 		"shortcutKey": "."
 	},
+        // Purely for turnsToBuild and civilopediaText. Unbuildable so it doesn't show in ImprovementPicker
+        {
+                "name": "Repair",
+                "terrainsCanBeBuiltOn": ["Land"],
+                "turnsToBuild": 2,
+                "shortcutKey": "E",
+                "uniques": ["Unbuildable"],
+                "civilopediaText": [{"text":"Repairs a pillaged Improvement or Route"}]
+        },
 	// Great Person improvements
 	{
 		"name": "Academy",


### PR DESCRIPTION
Adding the repair option to TileImprovements to match the latest Unciv version. This makes it possible to repair pillaged improvements.