### PR TITLE
Match aiUnitCostModifier among Chieftain, Warlord, Prince same as aiCityGrowthModifier

### DIFF
--- a/jsons/Difficulties.json
+++ b/jsons/Difficulties.json
@@ -108,7 +108,7 @@
 		"barbarianBonus": 0.35,
 		"playerBonusStartingUnits": ["Civilian Convoy", "Scout"],
 		"aiCityGrowthModifier": 0.5,
-		"aiUnitCostModifier": 0.6,
+		"aiUnitCostModifier": 0.5,
 		"aiBuildingCostModifier": 1,
 		"aiWonderCostModifier": 1,
 		"aiBuildingMaintenanceModifier": 0.35,


### PR DESCRIPTION
https://github.com/GeneralWadaling/DeCiv/commit/9ca64d3d8a0aae5f3ee1c469b46eb34e7a5f1c19 overhauled Difficulties.json.
The changes to the `aiUnitCostModifier`s were thus:
||Settler|Chieftain|Warlord|Prince|King|Emperor|Immortal|Deity|
|------------------|-------|---------|-------|------|----|-------|--------|-----|
|old `aiUnitCostModifier`|1.75|1.3|1.1|1.0|0.85|0.85|0.65|0.5|
|new `aiUnitCostModifier`|1.25|0.5|0.6|0.5|0.40|0.30|0.20|0.2|

I don't know what @9kgsofrice *intended* to type, but I'm pretty sure it wasn't that.

This takes a guess and sets `aiUnitCostModifier` to be the same for Chieftain, Warlord, and Prince, same as `aiCityGrowthModifier` is.

Closes https://github.com/SpacedOutChicken/DeCiv-Redux/issues/113.